### PR TITLE
chore: modulated the nodes of the Langchain pipeline + minor refinements to syntax

### DIFF
--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -10,7 +10,7 @@ from pipelines.node.content_retrieval import (
 from pipelines.node.note_taker import research_note_taker, note_taker_chain
 from pipelines.node.summary_writer import research_summary_writer, summary_writer_chain
 from pipelines.node.politician_commentary import (
-    run_politician_commentry_finder,
+    run_politician_commentary_finder,
     politician_commentary_chain,
 )
 from pipelines.node.report_formatter import report_formatter, report_formatter_chain
@@ -23,7 +23,7 @@ __all__ = [
     "run_content_retrieval",
     "research_note_taker",
     "research_summary_writer",
-    "run_politician_commentry_finder",
+    "run_politician_commentary_finder",
     "report_formatter",
     "send_email_to_subscribers",
     "legislation_finder_chain",

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -1,19 +1,35 @@
-from pipelines.nv_local import (
-    chain,
+from pipelines.nv_local import chain, run_pipeline
+from pipelines.node.legislation_finder import (
     run_legislation_finder,
-    run_content_retrieval,
-    research_note_taker,
-    research_summary_writer,
-    run_politician_commentry_finder,
-    report_formatter,
+    legislation_finder_chain,
 )
+from pipelines.node.content_retrieval import (
+    run_content_retrieval,
+    content_retrieval_chain,
+)
+from pipelines.node.note_taker import research_note_taker, note_taker_chain
+from pipelines.node.summary_writer import research_summary_writer, summary_writer_chain
+from pipelines.node.politician_commentary import (
+    run_politician_commentry_finder,
+    politician_commentary_chain,
+)
+from pipelines.node.report_formatter import report_formatter, report_formatter_chain
+from pipelines.node.email_sender import send_email_to_subscribers
 
 __all__ = [
     "chain",
+    "run_pipeline",
     "run_legislation_finder",
     "run_content_retrieval",
     "research_note_taker",
     "research_summary_writer",
     "run_politician_commentry_finder",
     "report_formatter",
+    "send_email_to_subscribers",
+    "legislation_finder_chain",
+    "content_retrieval_chain",
+    "note_taker_chain",
+    "summary_writer_chain",
+    "politician_commentary_chain",
+    "report_formatter_chain",
 ]

--- a/pipelines/node/content_retrieval.py
+++ b/pipelines/node/content_retrieval.py
@@ -1,0 +1,31 @@
+import httpx
+
+from langchain_core.runnables import RunnableLambda
+
+from utils.schemas import ChainData
+
+
+def run_content_retrieval(inputs: ChainData) -> ChainData:
+    legislation_sources = inputs.get("legislation_sources", [])
+
+    legislation_content = []
+
+    for source in legislation_sources:
+        url = source.get("url") if isinstance(source, dict) else source
+
+        if not url:
+            legislation_content.append(f"[Invalid source: {source}]")
+            continue
+
+        try:
+            markdown_url = f"https://markdown.new/{url}"
+            response = httpx.get(markdown_url, timeout=30, follow_redirects=True)
+            response.raise_for_status()
+            legislation_content.append(response.text)
+        except httpx.HTTPError:
+            legislation_content.append(f"[Failed to fetch: {url}]")
+
+    return {**inputs, "legislation_content": legislation_content}
+
+
+content_retrieval_chain = RunnableLambda(run_content_retrieval)

--- a/pipelines/node/email_sender.py
+++ b/pipelines/node/email_sender.py
@@ -1,0 +1,194 @@
+import json
+import os
+import smtplib
+import ssl
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from threading import Lock
+from typing import List
+
+import markdown
+from supabase import create_client, Client
+
+from utils.schemas.state import ChainData
+
+
+class SMTPConnectionPool:
+    def __init__(self, pool_size=10, smtp_host="smtp.gmail.com", smtp_port=587):
+        self.pool_size = pool_size
+        self.smtp_host = smtp_host
+        self.smtp_port = smtp_port
+        self.connections: List[smtplib.SMTP] = []
+        self.lock = Lock()
+        self._init_pool()
+
+    def _create_connection(self) -> smtplib.SMTP:
+        context = ssl.create_default_context()
+        server = smtplib.SMTP(self.smtp_host, self.smtp_port)
+        server.ehlo()
+        server.starttls(context=context)
+        server.ehlo()
+        server.login(os.environ["SMTP_EMAIL"], os.environ["SMTP_APP_PASSWORD"])
+        return server
+
+    def _init_pool(self):
+        for _ in range(self.pool_size):
+            self.connections.append(self._create_connection())
+
+    def get_connection(self) -> smtplib.SMTP:
+        with self.lock:
+            return self.connections.pop()
+
+    def return_connection(self, conn: smtplib.SMTP):
+        with self.lock:
+            self.connections.append(conn)
+
+    def close_all(self):
+        with self.lock:
+            for conn in self.connections:
+                try:
+                    conn.quit()
+                except:
+                    pass
+
+
+def load_template() -> str:
+    template_path = os.path.join(
+        os.path.dirname(__file__), "..", "templates", "email_report.html"
+    )
+    with open(template_path, "r") as f:
+        return f.read()
+
+
+def convert_markdown_to_html(markdown_content: str) -> str:
+    return markdown.markdown(markdown_content)
+
+
+def render_template(html_content: str) -> str:
+    template = load_template()
+    return template.replace("{{CONTENT}}", html_content)
+
+
+def get_subscribers() -> List[str]:
+    supabase_url = os.environ["SUPABASE_URL"]
+    supabase_key = os.environ["SUPABASE_KEY"]
+    client: Client = create_client(supabase_url, supabase_key)
+
+    response = client.table("subscriptions").select("contact").execute()
+
+    emails = []
+    for item in response.data:
+        contact = item.get("contact")
+        if contact:
+            emails.append(contact)
+
+    return emails
+
+
+def send_single_email(
+    pool: SMTPConnectionPool,
+    email: str,
+    subject: str,
+    html_body: str,
+    failures: List[dict],
+    failures_lock: Lock,
+) -> bool:
+    conn = None
+    try:
+        conn = pool.get_connection()
+
+        msg = f"""From: {os.environ["SMTP_EMAIL"]}
+To: {email}
+Subject: {subject}
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+{html_body}
+"""
+
+        conn.sendmail(os.environ["SMTP_EMAIL"], email, msg)
+
+        time.sleep(0.5)
+
+        return True
+    except Exception as e:
+        with failures_lock:
+            failures.append(
+                {
+                    "email": email,
+                    "error": str(e),
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+            )
+        return False
+    finally:
+        if conn:
+            pool.return_connection(conn)
+
+
+def send_batch(
+    pool: SMTPConnectionPool,
+    emails: List[str],
+    subject: str,
+    html_body: str,
+    failures: List[dict],
+    failures_lock: Lock,
+):
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = []
+        for email in emails:
+            future = executor.submit(
+                send_single_email,
+                pool,
+                email,
+                subject,
+                html_body,
+                failures,
+                failures_lock,
+            )
+            futures.append(future)
+        for future in futures:
+            future.result()
+
+
+def save_failures(failures: List[dict]):
+    if not failures:
+        return
+    failures_path = os.path.join(os.path.dirname(__file__), "..", "email_failures.json")
+    with open(failures_path, "w") as f:
+        json.dump(failures, f, indent=2)
+
+
+def send_email_to_subscribers(inputs: ChainData) -> ChainData:
+    markdown_report = inputs.get("markdown_report")
+
+    if not markdown_report:
+        return inputs
+
+    emails = get_subscribers()
+
+    if not emails:
+        return inputs
+
+    html_content = convert_markdown_to_html(markdown_report)
+    html_body = render_template(html_content)
+
+    pool = SMTPConnectionPool(pool_size=10)
+    failures: List[dict] = []
+    failures_lock = Lock()
+
+    try:
+        waves = [emails[i : i + 100] for i in range(0, len(emails), 100)]
+
+        for wave in waves:
+            send_batch(
+                pool, wave, "NV Local Report", html_body, failures, failures_lock
+            )
+            time.sleep(1)
+    finally:
+        pool.close_all()
+
+    save_failures(failures)
+
+    return inputs

--- a/pipelines/node/email_sender.py
+++ b/pipelines/node/email_sender.py
@@ -6,7 +6,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from threading import Lock
-from typing import List
 
 import markdown
 from supabase import create_client, Client
@@ -19,7 +18,7 @@ class SMTPConnectionPool:
         self.pool_size = pool_size
         self.smtp_host = smtp_host
         self.smtp_port = smtp_port
-        self.connections: List[smtplib.SMTP] = []
+        self.connections: list[smtplib.SMTP] = []
         self.lock = Lock()
         self._init_pool()
 
@@ -70,7 +69,7 @@ def render_template(html_content: str) -> str:
     return template.replace("{{CONTENT}}", html_content)
 
 
-def get_subscribers() -> List[str]:
+def get_subscribers() -> list[str]:
     supabase_url = os.environ["SUPABASE_URL"]
     supabase_key = os.environ["SUPABASE_KEY"]
     client: Client = create_client(supabase_url, supabase_key)
@@ -91,7 +90,7 @@ def send_single_email(
     email: str,
     subject: str,
     html_body: str,
-    failures: List[dict],
+    failures: list[dict],
     failures_lock: Lock,
 ) -> bool:
     conn = None
@@ -129,10 +128,10 @@ Content-Type: text/html; charset=utf-8
 
 def send_batch(
     pool: SMTPConnectionPool,
-    emails: List[str],
+    emails: list[str],
     subject: str,
     html_body: str,
-    failures: List[dict],
+    failures: list[dict],
     failures_lock: Lock,
 ):
     with ThreadPoolExecutor(max_workers=10) as executor:
@@ -152,7 +151,7 @@ def send_batch(
             future.result()
 
 
-def save_failures(failures: List[dict]):
+def save_failures(failures: list[dict]):
     if not failures:
         return
     failures_path = os.path.join(os.path.dirname(__file__), "..", "email_failures.json")
@@ -175,7 +174,7 @@ def send_email_to_subscribers(inputs: ChainData) -> ChainData:
     html_body = render_template(html_content)
 
     pool = SMTPConnectionPool(pool_size=10)
-    failures: List[dict] = []
+    failures: list[dict] = []
     failures_lock = Lock()
 
     try:

--- a/pipelines/node/legislation_finder.py
+++ b/pipelines/node/legislation_finder.py
@@ -1,0 +1,18 @@
+from langchain_core.runnables import RunnableLambda
+
+from utils.schemas import ChainData
+
+
+def run_legislation_finder(inputs: ChainData) -> ChainData:
+    from agents.legislation_finder import legislation_finder_agent
+
+    city = inputs.get("city", "Unknown")
+
+    agent_result = legislation_finder_agent.invoke({"city": city})
+
+    legislation_sources = agent_result.get("reliable_legislation_sources", [])
+
+    return {**inputs, "legislation_sources": legislation_sources}
+
+
+legislation_finder_chain = RunnableLambda(run_legislation_finder)

--- a/pipelines/node/note_taker.py
+++ b/pipelines/node/note_taker.py
@@ -1,0 +1,27 @@
+from langchain_core.runnables import RunnableLambda
+
+from utils.schemas import ChainData
+from utils.llm import get_llm
+from config.system_prompts import note_taker_sys_prompt
+
+model = get_llm()
+
+
+def research_note_taker(inputs: ChainData) -> ChainData:
+    raw_content_list = inputs.get("legislation_content", [])
+
+    if not raw_content_list:
+        return {**inputs, "notes": "No legislation content found."}
+
+    raw_content = "\n".join(raw_content_list)
+
+    system_prompt = note_taker_sys_prompt.format(raw_content=raw_content)
+
+    ai_generated_notes = model.invoke(
+        [{"role": "system", "content": system_prompt}],
+    )
+
+    return {**inputs, "notes": str(ai_generated_notes.content)}
+
+
+note_taker_chain = RunnableLambda(research_note_taker)

--- a/pipelines/node/politician_commentary.py
+++ b/pipelines/node/politician_commentary.py
@@ -3,7 +3,7 @@ from langchain_core.runnables import RunnableLambda
 from utils.schemas import ChainData
 
 
-def run_politician_commentry_finder(inputs: ChainData) -> ChainData:
+def run_politician_commentary_finder(inputs: ChainData) -> ChainData:
     from agents.political_commentry_finder import political_commentry_agent
 
     city = inputs.get("city", "Unknown")
@@ -15,4 +15,4 @@ def run_politician_commentry_finder(inputs: ChainData) -> ChainData:
     return {**inputs, "politician_public_statements": political_commentary}
 
 
-politician_commentary_chain = RunnableLambda(run_politician_commentry_finder)
+politician_commentary_chain = RunnableLambda(run_politician_commentary_finder)

--- a/pipelines/node/politician_commentary.py
+++ b/pipelines/node/politician_commentary.py
@@ -1,0 +1,18 @@
+from langchain_core.runnables import RunnableLambda
+
+from utils.schemas import ChainData
+
+
+def run_politician_commentry_finder(inputs: ChainData) -> ChainData:
+    from agents.political_commentry_finder import political_commentry_agent
+
+    city = inputs.get("city", "Unknown")
+
+    agent_result = political_commentry_agent.invoke({"city": city})
+
+    political_commentary = agent_result.get("political_commentary", [])
+
+    return {**inputs, "politician_public_statements": political_commentary}
+
+
+politician_commentary_chain = RunnableLambda(run_politician_commentry_finder)

--- a/pipelines/node/report_formatter.py
+++ b/pipelines/node/report_formatter.py
@@ -1,0 +1,48 @@
+from langchain_core.runnables import RunnableLambda
+
+from utils.schemas import ChainData
+
+
+def report_formatter(inputs: ChainData) -> ChainData:
+    legislation_summary = inputs.get("legislation_summary")
+    public_statements = inputs.get("politician_public_statements")
+
+    if legislation_summary is None:
+        return {
+            **inputs,
+            "markdown_report": "# No Legislation Found\n\nNo recent legislation was found for the specified city. Try a different city or check back later for updates.",
+        }
+
+    lines = [
+        f"# {legislation_summary.title}",
+        "",
+        "## Summary",
+        "",
+        legislation_summary.summary,
+        "",
+        "## Full Report",
+        "",
+        legislation_summary.body,
+        "",
+        "---",
+        "",
+        "## Politician Public Statements",
+        "### Coming Soon!",
+        "",
+    ]
+
+    for politician in public_statements:
+        lines.append(f"### {politician['name']}")
+        lines.append("")
+        for statement in politician["statement_summaries"]:
+            lines.append(f"**Legislation Source Link:** {statement['source']}")
+            lines.append("")
+            lines.append(statement["summary"])
+            lines.append("")
+
+    markdown_report = "\n".join(lines)
+
+    return {**inputs, "markdown_report": markdown_report}
+
+
+report_formatter_chain = RunnableLambda(report_formatter)

--- a/pipelines/node/summary_writer.py
+++ b/pipelines/node/summary_writer.py
@@ -1,0 +1,37 @@
+from langchain_core.runnables import RunnableLambda
+
+from utils.schemas import ChainData, WriterOutput
+from utils.llm import get_structured_llm
+from config.system_prompts import writer_sys_prompt
+
+model = get_structured_llm(WriterOutput)
+
+
+def research_summary_writer(inputs: ChainData) -> ChainData:
+    notes = inputs.get("notes")
+
+    system_prompt = writer_sys_prompt.format(notes=notes)
+
+    ai_generated_summary: WriterOutput = model.invoke(
+        [{"role": "system", "content": system_prompt}],
+    )
+
+    if ai_generated_summary is None:
+        return {**inputs, "legislation_summary": None}
+
+    title_lower = (
+        ai_generated_summary.title.lower().strip() if ai_generated_summary.title else ""
+    )
+    no_title_patterns = ("no content", "no recent", "no legislation", "none", "")
+
+    if (
+        title_lower in no_title_patterns
+        or title_lower.startswith("no ")
+        or title_lower.startswith("n/a")
+    ):
+        return {**inputs, "legislation_summary": None}
+
+    return {**inputs, "legislation_summary": ai_generated_summary}
+
+
+summary_writer_chain = RunnableLambda(research_summary_writer)

--- a/pipelines/nv_local.py
+++ b/pipelines/nv_local.py
@@ -16,23 +16,12 @@ The pipeline uses a RunnableLambda-based chain that passes data between
 stages via a ChainData dictionary.
 """
 
-from langchain_core.runnables import RunnableLambda
-
-from pipelines.node.legislation_finder import (
-    run_legislation_finder,
-    legislation_finder_chain,
-)
-from pipelines.node.content_retrieval import (
-    run_content_retrieval,
-    content_retrieval_chain,
-)
-from pipelines.node.note_taker import research_note_taker, note_taker_chain
-from pipelines.node.summary_writer import research_summary_writer, summary_writer_chain
-from pipelines.node.politician_commentary import (
-    run_politician_commentry_finder,
-    politician_commentary_chain,
-)
-from pipelines.node.report_formatter import report_formatter, report_formatter_chain
+from pipelines.node.legislation_finder import legislation_finder_chain
+from pipelines.node.content_retrieval import content_retrieval_chain
+from pipelines.node.note_taker import note_taker_chain
+from pipelines.node.summary_writer import summary_writer_chain
+from pipelines.node.politician_commentary import politician_commentary_chain
+from pipelines.node.report_formatter import report_formatter_chain
 from pipelines.node.email_sender import send_email_to_subscribers
 
 chain = (

--- a/pipelines/nv_local.py
+++ b/pipelines/nv_local.py
@@ -16,166 +16,33 @@ The pipeline uses a RunnableLambda-based chain that passes data between
 stages via a ChainData dictionary.
 """
 
-import httpx
-
 from langchain_core.runnables import RunnableLambda
 
-from agents.legislation_finder import legislation_finder_agent
-from agents.political_commentry_finder import political_commentry_agent
-
-from utils.schemas import WriterOutput, ChainData
-from utils.llm import get_llm, get_structured_llm
-from utils.email_sender import send_email_to_subscribers
-from config.system_prompts import writer_sys_prompt, note_taker_sys_prompt
-
-model = get_llm()
-
-
-def run_legislation_finder(inputs: ChainData) -> ChainData:
-    """Run the legislation finder agent as a node."""
-    city = inputs.get("city", "Unknown")
-
-    agent_result = legislation_finder_agent.invoke({"city": city})
-
-    legislation_sources = agent_result.get("reliable_legislation_sources", [])
-
-    return {**inputs, "legislation_sources": legislation_sources}
-
-
-def run_content_retrieval(inputs: ChainData) -> ChainData:
-    """Fetch content from legislation sources."""
-    legislation_sources = inputs.get("legislation_sources", [])
-
-    legislation_content = []
-
-    for source in legislation_sources:
-        url = source.get("url") if isinstance(source, dict) else source
-
-        if not url:
-            legislation_content.append(f"[Invalid source: {source}]")
-            continue
-
-        try:
-            markdown_url = f"https://markdown.new/{url}"
-            response = httpx.get(markdown_url, timeout=30, follow_redirects=True)
-            response.raise_for_status()
-            legislation_content.append(response.text)
-        except httpx.HTTPError:
-            legislation_content.append(f"[Failed to fetch: {url}]")
-
-    return {**inputs, "legislation_content": legislation_content}
-
-
-def research_note_taker(inputs: ChainData) -> ChainData:
-    """Analyze legislation content and create notes."""
-    raw_content_list = inputs.get("legislation_content", [])
-
-    if not raw_content_list:
-        return {**inputs, "notes": "No legislation content found."}
-
-    raw_content = "\n".join(raw_content_list)
-
-    system_prompt = note_taker_sys_prompt.format(raw_content=raw_content)
-
-    ai_generated_notes = model.invoke(
-        [{"role": "system", "content": system_prompt}],
-    )
-
-    return {**inputs, "notes": str(ai_generated_notes.content)}
-
-
-def research_summary_writer(inputs: ChainData) -> ChainData:
-    """Generate final output using LLM with structured output."""
-    notes = inputs.get("notes")
-
-    system_prompt = writer_sys_prompt.format(notes=notes)
-
-    structured_model = get_structured_llm(WriterOutput)
-
-    ai_generated_summary: WriterOutput = structured_model.invoke(
-        [{"role": "system", "content": system_prompt}],
-    )
-
-    if ai_generated_summary is None:
-        return {**inputs, "legislation_summary": None}
-
-    title_lower = (
-        ai_generated_summary.title.lower().strip() if ai_generated_summary.title else ""
-    )
-    no_title_patterns = ("no content", "no recent", "no legislation", "none", "")
-
-    if (
-        title_lower in no_title_patterns
-        or title_lower.startswith("no ")
-        or title_lower.startswith("n/a")
-    ):
-        return {**inputs, "legislation_summary": None}
-
-    return {**inputs, "legislation_summary": ai_generated_summary}
-
-
-def run_politician_commentry_finder(inputs: ChainData) -> ChainData:
-    """Run the political commentary finder agent as a node."""
-    city = inputs.get("city", "Unknown")
-
-    agent_result = political_commentry_agent.invoke({"city": city})
-
-    political_commentary = agent_result.get("political_commentary", [])
-
-    return {**inputs, "politician_public_statements": political_commentary}
-
-
-def report_formatter(inputs: ChainData) -> ChainData:
-    """Format a final report using the legislative summary and the politician public statements."""
-    legislation_summary = inputs.get("legislation_summary")
-    public_statements = inputs.get("politician_public_statements")
-
-    if legislation_summary is None:
-        return {
-            **inputs,
-            "markdown_report": "# No Legislation Found\n\nNo recent legislation was found for the specified city. Try a different city or check back later for updates.",
-        }
-
-    lines = [
-        f"# {legislation_summary.title}",
-        "",
-        "## Summary",
-        "",
-        legislation_summary.summary,
-        "",
-        "## Full Report",
-        "",
-        legislation_summary.body,
-        "",
-        "---",
-        "",
-        "## Politician Public Statements",
-        "### Coming Soon!",
-        "",
-    ]
-
-    for politician in public_statements:
-        lines.append(f"### {politician['name']}")
-        lines.append("")
-        for statement in politician["statement_summaries"]:
-            lines.append(f"**Legislation Source Link:** {statement['source']}")
-            lines.append("")
-            lines.append(statement["summary"])
-            lines.append("")
-
-    markdown_report = "\n".join(lines)
-
-    return {**inputs, "markdown_report": markdown_report}
-
+from pipelines.node.legislation_finder import (
+    run_legislation_finder,
+    legislation_finder_chain,
+)
+from pipelines.node.content_retrieval import (
+    run_content_retrieval,
+    content_retrieval_chain,
+)
+from pipelines.node.note_taker import research_note_taker, note_taker_chain
+from pipelines.node.summary_writer import research_summary_writer, summary_writer_chain
+from pipelines.node.politician_commentary import (
+    run_politician_commentry_finder,
+    politician_commentary_chain,
+)
+from pipelines.node.report_formatter import report_formatter, report_formatter_chain
+from pipelines.node.email_sender import send_email_to_subscribers
 
 chain = (
-    RunnableLambda(run_legislation_finder)
-    | RunnableLambda(run_content_retrieval)
-    | RunnableLambda(research_note_taker)
-    | RunnableLambda(research_summary_writer)
-    | RunnableLambda(run_politician_commentry_finder)
-    | RunnableLambda(report_formatter)
-    | RunnableLambda(send_email_to_subscribers)
+    legislation_finder_chain
+    | content_retrieval_chain
+    | note_taker_chain
+    | summary_writer_chain
+    | politician_commentary_chain
+    | report_formatter_chain
+    | send_email_to_subscribers
 )
 
 


### PR DESCRIPTION
## Summary

Extracts each pipeline stage from a monolithic `pipelines/nv_local.py` into dedicated node files under `pipelines/node/`, making each stage independently readable, testable, and modifiable.

## Changes

- **`pipelines/node/legislation_finder.py`** *(new)* — wraps the legislation finder agent invocation
- **`pipelines/node/content_retrieval.py`** *(new)* — fetches each URL via `https://markdown.new/<url>` and stores extracted text
- **`pipelines/node/note_taker.py`** *(new)* — single LLM call to compress raw page text into dense notes
- **`pipelines/node/summary_writer.py`** *(new)* — structured LLM call producing `WriterOutput` (title, category, impact, etc.)
- **`pipelines/node/politician_commentary.py`** *(new)* — wraps the political commentary agent invocation
- **`pipelines/node/report_formatter.py`** *(new)* — assembles the final markdown report from all upstream outputs
- **`pipelines/node/email_sender.py`** *(new)* — wraps `utils/email_sender.py` as a pipeline node
- **`pipelines/nv_local.py`** — reduced from 158 lines to 14 lines; now only composes the chain from the node imports
- **Syntax fixes**: remove unused `RunnableLambda` and function imports; replace deprecated `typing.List` with built-in `list`; fix typo `commentry` → `commentary`

## Why

With all pipeline logic in one file, adding or debugging a single stage required navigating the entire chain. Splitting into node files means each file has one job, diffs are localized to the affected stage, and future developers can understand or replace a single node without reading the whole pipeline.