### PR TITLE
docs: revamp documentation for CLI-first architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+This project is a small Python codebase with a CLI-oriented workflow.
+
+## Development Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Environment variables:
+
+- Copy `.env.example` to `.env` and set required keys.
+- `run_cli_main.py` loads `.env`; `main.py` expects env vars to already be present.
+
+## Running Locally
+
+```bash
+python main.py
+```
+
+Rich console wrapper:
+
+```bash
+python run_cli_main.py
+```
+
+## Testing
+
+There is no dedicated test suite in this repository at the moment.
+
+Quick non-destructive checks you can run:
+
+```bash
+python -m compileall -q .
+```
+
+If you add tests, include how to run them in your PR description and consider updating this file.
+
+## Linting / Formatting
+
+There is no pinned linter/formatter configuration in-repo (no `pyproject.toml`).
+
+Guidelines:
+
+- Keep changes focused and consistent with nearby code.
+- Prefer explicit, typed data structures (`TypedDict` / Pydantic models) where the pipeline crosses boundaries.
+- Avoid introducing new runtime dependencies unless necessary.
+
+## Branching
+
+- Create feature branches off `main`: `feature/<short-description>` or `fix/<short-description>`
+- Keep PRs small and focused.
+
+## Pull Request Checklist
+
+- [ ] The change is scoped and explained (what + why)
+- [ ] `python -m compileall -q .` succeeds
+- [ ] Any new env vars are documented in `README.md` and/or `docs/OPERATIONS.md`
+- [ ] Any behavior changes to the pipeline are reflected in `docs/ARCHITECTURE.md`

--- a/README.md
+++ b/README.md
@@ -1,189 +1,110 @@
 # Next Voters Local
 
-> **Hold your local representative accountable to their actions**  
-> An intelligent multi-agent deep research system that investigates municipal legislation, extracts politician positions, and presents factual, bias-resistant information to voters.
+NV Local is a Python CLI that runs a small, multi-step research pipeline per city:
 
-<div align="center">
+1) discover recent municipal legislation sources
+2) fetch the linked pages and extract text
+3) turn the text into dense notes and a structured summary
+4) format a markdown report
+5) optionally email the report to subscribers (Supabase + SMTP)
 
-[![GitHub License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+Docs:
+- `docs/ARCHITECTURE.md`
+- `docs/OPERATIONS.md`
+- `CONTRIBUTING.md`
 
-[Features](#-features) • [Getting Started](#-getting-started) • [How It Works](#-how-it-works) • [Architecture](#-architecture) • [Contributing](#-contributing)
+## Features
 
-</div>
+- Multi-city execution (one pipeline per city, run concurrently)
+- Legislation discovery via Brave Search (MCP) with Goggles rules
+- Source vetting via Wikidata lookups + an LLM-based classifier
+- Markdown report output (stdout and/or `-o` to file)
+- Optional email delivery (Supabase subscription list + SMTP)
 
----
+## Architecture At A Glance
 
-## 🎯 Features
+- Entry points: `python main.py` (plain stdout) or `python run_cli_main.py` (Rich console)
+- Pipeline: `pipelines/nv_local.py` composes a fixed chain of nodes
+- Agents: LangGraph ReAct-style agents for legislation discovery and political commentary
+- LLM steps: note-taking and summary writing are single-call LLM transforms
+- External services: OpenAI (LLM), Brave Search (web search), Wikidata (org classification), `markdown.new` (HTML -> markdown-ish extraction), optional Supabase + SMTP
 
-- **🔍 Intelligent Legislation Discovery** — Autonomous web search for recent municipal legislation with Wikidata-backed source validation
-- **📊 Bias-Resistant Analysis** — Five-layer debiasing strategy grounded in academic research (Gallegos et al., 2024; Phute et al., 2023)
-- **🗳️ Politician Position Extraction** — Scrapes and analyzes politician statements, press releases, and voting records
-- **🛡️ Identity Protection** — Anonymizes politician names before bias analysis, ensuring fair rhetoric evaluation
-- **📝 Factual Summaries** — Generates clean, digestible summaries backed by authoritative sources
-- **⚙️ Modular Agent System** — Composable ReAct agents with clear separation of concerns
-- **🌐 Wikidata Integration** — Validates source reliability using structured knowledge about organizations
+## Prerequisites
 
----
+- Python 3.10+
+- An OpenAI API key (used by `langchain-openai`)
+- A Brave Search API key (used via Smithery-hosted MCP)
+- Optional: Twitter API credentials (for the social-media tool)
+- Optional: Supabase + SMTP credentials (to email reports)
 
-## 🚀 Quick Start
+## Quickstart
 
-### Prerequisites
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
-- **Python** 3.10+
-- **OpenAI API Key** (for GPT-4, GPT-4o-mini)
-- **Tavily API Key** (for web search)
-- **Git**
+Configure environment variables:
 
-### Installation
+```bash
+cp .env.example .env
+```
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/hemitoncode/Next-Voters-Local.git
-   cd Next-Voters-Local
-   ```
+Notes:
+- `python main.py` does not call `load_dotenv()`. Export env vars in your shell, or use the Rich wrapper (`python run_cli_main.py`) which loads `.env`.
+- The default cities are hard-coded in `data/__init__.py` as `SUPPORTED_CITIES`.
 
-2. **Create a virtual environment**
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   ```
+Run:
 
-3. **Install dependencies**
-   ```bash
-   pip install -r requirements.txt
-   ```
+```bash
+python main.py
+```
 
-4. **Configure API keys**
-   ```bash
-   cp .env.example .env
-   # Edit .env with your OpenAI and Tavily API keys
-   ```
+Save output:
 
-5. **Run the system**
-   ```bash
-   python main.py
-   ```
-   The pipeline runs three predefined municipalities in parallel threads: `Toronto`, `New York City`, and `San Diego`. The markdown report prints to stdout, `-o <path>` saves it to a file, and `-q` suppresses the printed output.
+```bash
+python main.py -o out/report.md
+```
 
-### 🐳 Container
+Quiet mode:
 
-- Build the updated CLI container:
+```bash
+python main.py -q -o out/report.md
+```
+
+## Configuration
+
+Required for the core pipeline:
+
+- `OPENAI_API_KEY`: OpenAI key used by `langchain-openai`
+- `BRAVE_SEARCH_API_KEY`: used by `utils/mcp/brave_client.py` to call the Smithery Brave Search MCP server
+
+Optional:
+
+- `TWITTER_API_KEY`, `TWITTER_BEARER_TOKEN`: enable the Twitter/X MCP client used by the political commentary tools
+- `SUPABASE_URL`, `SUPABASE_KEY`: used to load subscriber emails from the `subscriptions` table
+- `SMTP_EMAIL`, `SMTP_APP_PASSWORD`: used to send HTML emails via SMTP (default host: `smtp.gmail.com:587`)
+
+## Common Tasks
+
+- Change the cities the CLI runs: edit `data/__init__.py` (`SUPPORTED_CITIES`)
+- Build and run the container:
   ```bash
   docker build -t next-voters-local -f docker/Dockerfile .
+  docker run --rm \
+    -e OPENAI_API_KEY \
+    -e BRAVE_SEARCH_API_KEY \
+    next-voters-local
   ```
-- Run the container:
-  ```bash
-  docker run --rm next-voters-local
-  ```
-The image executes `main.py` by default, so the pipeline runs `Toronto`, `New York City`, and `San Diego` in parallel threads and streams the markdown summary to stdout.
 
----
-### Key Design Principles
+## Troubleshooting
 
-1. **Minimal Agency** — ReAct agents only where unpredictable targets or retry loops exist such as during legislative activity discovery phase. Everything else is a deterministic LLM call or pure code.
-2. **No Supervision** — Sequential DAG, no supervisor node. Routing is always the same; routing costs would waste API calls.
-3. **Judge Isolation** — The Judge never sees real names, never sees graph state. Its narrow scope is its strength.
-4. **Source Authority** — Only `.gov`, `.gc.ca`, and Wikidata-validated organizations pass reliability checks. No blogs, no opinion sites, no partisan media.
-5. **Cite or Reject** — Every claim must cite its source. Unsupported inferences are rejected.
+- Brave search failures: ensure `BRAVE_SEARCH_API_KEY` is set; the error originates in `utils/mcp/brave_client.py`
+- OpenAI auth errors: ensure `OPENAI_API_KEY` is set in the environment seen by the process
+- Empty or thin reports: the pipeline only summarizes what it can fetch; some sites may block scraping or fail via `markdown.new`
+- Email not sent: the email step is skipped unless all of `SMTP_EMAIL`, `SMTP_APP_PASSWORD`, `SUPABASE_URL`, `SUPABASE_KEY` are set
 
-### Technology Stack
+## License
 
-| Component | Technology |
-|-----------|-----------|
-| **Orchestration** | LangChain Expression Language |
-| **LLM Provider** | OpenAI (GPT-4, GPT-4o-mini) |
-| **LLM Framework** | LangChain 1.1+ |
-| **Web Search** | Tavily Search API |
-| **Organization Lookup** | Wikidata REST API + SPARQL |
-| **Web Scraping** | Generated Python code (REPL sandbox) |
-| **NER / Anonymization** | spaCy (or equivalent) |
-| **Config** | python-dotenv |
-| **HTTP Client** | httpx |
-
----
-
-## 🛡️ Bias Resistance
-
-Next Voters Local implements **two core safeguards** against bias:
-
-| Safeguard | Where | Method |
-|-----------|-------|--------|
-| **LLM-as-a-Defense: Name Anonymizer** | Anonymizer (LLM) | Use language model to identify & replace politician names before any analysis |
-| **Source Reliability Measure** | Legislation Finder | Validate organizations via Wikidata to ensure only unbiased, authoritative sources are used |
-
-### Implementation
-
-- **Name Anonymization** — All politician identities are removed before rhetoric analysis. This prevents the LLM from making identity-based inferences.
-- **Source Validation** — Every source is checked against Wikidata for organizational classification. Only `.gov`, `.gc.ca`, and nonpartisan organizations pass through. No blogs, opinion sites, or politically-aligned media.
-
-### Responsible Use
-
-This system is designed for **informational purposes only**. Users should:
-- ✅ Verify claims using the provided source URLs
-- ✅ Cross-reference multiple sources before forming opinions
-- ✅ Understand this tool supplements, not replaces, civic engagement
-- ❌ Not rely on a single summary for critical decisions
-
-## 📝 Contributing
-
-Contributions are welcome! Please follow these guidelines:
-
-1. **Fork** the repository
-2. **Create a feature branch**: `git checkout -b feature/your-feature-name`
-3. **Make your changes** with clear commit messages
-4. **Test** locally: `python main.py`
-5. **Submit a Pull Request** with a description of changes
-
-#### ⚠️ Note: You are not entitled to payment for your services. You are also not affiliated with Next Voters, and you may not claim any titles of employment within the organization. 
-
-### Reporting Issues
-
-Found a bug? Please open an [issue](https://github.com/hemitoncode/Next-Voters-Local/issues) with:
-- Clear description of the problem
-- Steps to reproduce
-- Expected vs. actual behavior
-- Python version & OS
-
----
-
-## 📚 References & Inspiration
-
-This project is informed by academic research on LLM bias and debiasing:
-
-- **Gallegos et al., 2024** — [Bias and Fairness in Large Language Models: A Survey](https://arxiv.org/abs/2402.01981) — Two-pass self-debiasing strategy (Layer 3)
-- **Phute et al., 2023** — [LLM Self Defense](https://arxiv.org/abs/2308.07308) — Judge-as-LLM design (Layer 4)
-- **OpenNorth** — [Canadian municipal representative data](https://opennorth.ca/)
-
----
-
-## 🤝 Acknowledgments
-
-- Built with [LangGraph](https://langchain-ai.github.io/langgraph/) for orchestration
-- Source validation powered by [Wikidata](https://www.wikidata.org/)
-- Search via [Tavily](https://www.tavily.com/)
-- LLM backbone: [OpenAI](https://openai.com/)
-
----
-
-## 📄 License
-
-This project is licensed under the [MIT License](LICENSE) — see the LICENSE file for details.
-
----
-
-## 💬 Contact & Support
-
-- **Issues & Discussions**: [GitHub Issues](https://github.com/hemitoncode/Next-Voters-Local/issues)
-- **Questions?** Check [CLAUDE.md](/.claude/CLAUDE.md) for development documentation
-
----
-
-<div align="center">
-
-**Empowering voters with factual, bias-resistant information about local legislation.**
-
-Made with ❤️ by Next Voters
-
-</div>
+MIT: see `LICENSE`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,86 @@
+# Architecture
+
+This repository implements a fixed, multi-step research pipeline that runs per city and produces a markdown report.
+
+## Components
+
+Code layout (high level):
+
+- `main.py`: entrypoint shim that calls `pipelines/nv_local.py:main`
+- `run_cli_main.py`: Rich console wrapper that loads `.env` and renders the report
+- `pipelines/nv_local.py`: composes the end-to-end chain and runs it for multiple cities concurrently
+- `pipelines/node/*`: individual pipeline nodes (small, single-purpose transforms)
+- `agents/*`: LangGraph ReAct agents built from `agents/base_agent_template.py`
+- `tools/*`: tool functions used by agents (web search, reliability checks, political figure discovery)
+- `utils/*`: shared helpers (LLM factory, MCP clients, schemas, Wikidata client)
+
+## Data Flow
+
+`pipelines/nv_local.py` composes these nodes into a single chain:
+
+1) `pipelines/node/legislation_finder.py`
+
+- Calls the ReAct agent in `agents/legislation_finder.py`
+- Agent tools:
+  - `tools/legislation_finder.py:web_search` (Brave Search via MCP + Goggles)
+  - `tools/legislation_finder.py:reliability_analysis` (Wikidata lookup + LLM classifier)
+- Output: `legislation_sources` (a list of URLs that passed reliability filtering)
+
+2) `pipelines/node/content_retrieval.py`
+
+- Fetches each URL via `https://markdown.new/<url>` and stores the returned text
+- Output: `legislation_content` (list of extracted page text blocks)
+
+3) `pipelines/node/note_taker.py`
+
+- Single LLM call to compress raw page text into dense notes
+- Output: `notes` (plain text)
+
+4) `pipelines/node/summary_writer.py`
+
+- Single LLM call with a structured output schema (`utils/schemas/pydantic.py:WriterOutput`)
+- Output: `legislation_summary` (or `None` if the LLM indicates no usable content)
+
+5) `pipelines/node/politician_commentary.py`
+
+- Calls the ReAct agent in `agents/political_commentry_finder.py`
+- Agent tools:
+  - `tools/political_commentry_finder.py:political_figure_finder` (OpenStreetMap Nominatim + OpenNorth Represent API for CA, WeVote API for US)
+  - `tools/political_commentry_finder.py:search_political_commentary` (Brave Search + per-page LLM extraction)
+  - `tools/political_commentry_finder.py:search_political_social_media` (Twitter MCP)
+- Output: `politician_public_statements`
+
+6) `pipelines/node/report_formatter.py`
+
+- Builds a markdown document from `legislation_summary` and politician statement data
+- Output: `markdown_report`
+
+7) `pipelines/node/email_sender.py` (optional)
+
+- If all required email env vars are present, loads subscribers from Supabase and sends the report via SMTP
+- Output: no change to the report; side-effect only
+
+## Runtime Model
+
+- Concurrency: `pipelines/nv_local.py:run_pipelines_for_cities` uses a `ThreadPoolExecutor` to run one city pipeline per thread.
+- State passing: pipeline nodes pass a simple `TypedDict` (`utils/schemas/state.py:ChainData`) from node to node.
+
+## Key Design Decisions
+
+- Fixed chain over dynamic routing: the pipeline is a stable sequence, so each run is easy to reason about and operate.
+- ReAct agents only where tool-use is needed: legislation discovery and political commentary use tools (web search, external APIs). Note-taking and summary writing are single LLM transforms.
+- Reliability gate before fetching: legislation URLs are filtered using Wikidata context and a small-model classifier; if the classifier output cannot be parsed, the safe fallback is to reject all sources.
+- HTML extraction via `markdown.new`: content retrieval delegates page-to-text conversion to an external service, keeping the local code simple but introducing a dependency that can fail on some domains.
+
+## External Dependencies
+
+- OpenAI (via `langchain-openai`): LLM calls
+- Brave Search (via Smithery-hosted MCP): web search
+- Wikidata REST + SPARQL: organization metadata used for source classification
+- OpenStreetMap Nominatim: country detection for a city name
+- OpenNorth Represent API (Canada) and WeVote API (USA): political figure discovery
+- Optional: Supabase and SMTP for email delivery
+
+## Known Gaps / WIP
+
+- The political commentary portion is still evolving; the report formatter expects a particular schema for public statements. If the political commentary agent returns non-empty data in a different shape, formatting may fail.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,89 @@
+# Operations
+
+This document describes how NV Local is typically run in development and how it is deployed in production-like environments.
+
+## Environments
+
+- Local dev: run `python main.py` or `python run_cli_main.py` from a virtualenv
+- Container: build and run `docker/Dockerfile`
+- CI/CD: GitHub Actions builds and pushes a container image to Azure Container Registry
+
+## Configuration And Secrets
+
+Core runtime secrets:
+
+- `OPENAI_API_KEY`
+- `BRAVE_SEARCH_API_KEY`
+
+Optional features:
+
+- Twitter MCP: `TWITTER_API_KEY`, `TWITTER_BEARER_TOKEN`
+- Email delivery: `SUPABASE_URL`, `SUPABASE_KEY`, `SMTP_EMAIL`, `SMTP_APP_PASSWORD`
+
+Operational guidance:
+
+- Prefer injecting secrets via your environment (shell export, container env vars, or Azure Key Vault).
+- `run_cli_main.py` calls `dotenv.load_dotenv()`; `main.py` does not.
+
+## Deployments
+
+### Container Image Build + Push
+
+GitHub workflow: `/.github/workflows/push-container-to-azure.yml`
+
+- Trigger: pushes to `main`, but the job only runs when either:
+  - the commit message is exactly `release`, or
+  - the workflow is run manually via `workflow_dispatch`
+- Output: image pushed to Azure Container Registry with two tags:
+  - `<login_server>/next-voters-local:<git_sha>`
+  - `<login_server>/next-voters-local:latest`
+
+### Runtime (Azure)
+
+The repo contains an Azure infrastructure diagram in `__diagrams__/azure-infrastructure.mmd`. The intended model is:
+
+- An Azure Container Apps Job pulls the image from ACR
+- A schedule triggers the job
+- Logs are emitted to stdout/stderr and collected by Azure Monitor / Log Analytics
+
+This repository does not include IaC for provisioning the Azure resources.
+
+## Logging And Monitoring
+
+- Primary logs: stdout/stderr from the container/job
+- Failures: per-city pipeline failures are captured and surfaced as `error` fields in the multi-city results
+
+If email sending is enabled:
+
+- A JSON file of delivery failures may be written (`email_failures.json`). In ephemeral containers this file is not durable unless you mount storage or ship logs elsewhere.
+
+## Data Storage And Backups
+
+- The core pipeline is stateless; it does not persist reports by default.
+- Email subscriber list is read from Supabase (table: `subscriptions`, column: `contact`). Backups, retention, and schema migrations are owned by the Supabase project.
+
+## Runbooks
+
+### Job Fails Immediately
+
+1) Check logs for missing env vars (common: `OPENAI_API_KEY` or `BRAVE_SEARCH_API_KEY`).
+2) If using `python main.py` locally, confirm your shell exports env vars (it does not auto-load `.env`).
+
+### Brave Search Errors
+
+Symptoms: errors mentioning `BRAVE_SEARCH_API_KEY` or failures in the MCP client.
+
+1) Verify the key is present in the runtime environment.
+2) Confirm outbound network access to `https://server.smithery.ai/`.
+3) If failures are intermittent, consider retries or reducing concurrency.
+
+### OpenAI Errors / Rate Limits
+
+1) Verify `OPENAI_API_KEY` and account quota.
+2) If rate-limited, reduce the number of cities run concurrently (edit `data/__init__.py`) or tune model usage.
+
+### Email Not Sending
+
+1) Email delivery is skipped unless all of `SMTP_EMAIL`, `SMTP_APP_PASSWORD`, `SUPABASE_URL`, `SUPABASE_KEY` are set.
+2) Confirm Supabase has rows in `subscriptions` with a non-empty `contact`.
+3) For Gmail SMTP, ensure an app password is used and SMTP access is permitted.


### PR DESCRIPTION
## Summary

First comprehensive documentation pass after the codebase was refactored from a script-based design to a LangGraph pipeline with a CLI entrypoint. Creates the foundational docs that all subsequent PRs build on.

## Changes

- **`README.md`** — rewrote from 157 lines to 78 lines; new version describes the pipeline-based architecture, CLI usage (`python main.py \<city\>`), and project purpose; removes the original script-centric instructions
- **`CONTRIBUTING.md`** *(new)* — developer setup guide: virtualenv creation, `pip install -r requirements.txt`, env var configuration, common commands, and guidance on running the pipeline locally
- **`docs/ARCHITECTURE.md`** *(new, 86 lines)* — documents the end-to-end pipeline (legislation_finder → content_retrieval → note_taker → summary_writer → politician_commentary → report_formatter → email_sender), agent tools, data flow, and key design decisions
- **`docs/OPERATIONS.md`** *(new, 89 lines)* — operational reference: Docker build/run commands, Azure Container App Job setup, environment variable reference, and logging/monitoring guidance

## Why

The project had no documentation after shifting from a workflow.py script to a proper LangGraph pipeline. New contributors had no reference for how the system was structured or how to run it. These four files establish a layered docs strategy: README for orientation, CONTRIBUTING for local setup, ARCHITECTURE for technical depth, OPERATIONS for deployment.