### PR TITLE
chore: add LLM as a judge evals

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,336 @@
+# NV Local Evaluation Suite
+
+Comprehensive evaluation suite for the NV Local municipal legislation research pipeline using DeepEval.
+
+## Overview
+
+This evaluation suite provides automated testing and quality assessment for all NV Local components:
+
+- **LegislationFinderAgent**: Finds relevant municipal legislation with reliability analysis
+- **SummaryWriter**: Creates structured summaries using Pydantic schema (WriterOutput)
+- **PoliticalCommentaryAgent**: Identifies political figures and their public statements
+- **ReportFormatter**: Generates well-structured markdown reports
+- **End-to-End Pipeline**: Complete pipeline from discovery to report
+
+## Installation
+
+```bash
+pip install deepeval pytest pytest-asyncio
+
+# Or install from requirements
+pip install -r requirements.txt
+```
+
+## Project Structure
+
+```
+evals/
+├── metrics/
+│   ├── __init__.py
+│   ├── legislation_accuracy.py    # Legislation relevance metrics
+│   ├── summary_quality.py          # Summary quality metrics
+│   ├── political_relevance.py      # Political figure relevance
+│   ├── report_formatting.py        # Markdown structure validation
+│   └── no_hallucination.py         # Hallucination detection
+├── test_legislation_finder.py      # Unit tests for legislation finder
+├── test_summary_writer.py          # Unit tests for summary writer
+├── test_political_commentary.py    # Unit tests for political commentary
+├── test_report_formatter.py        # Unit tests for report formatter
+├── test_e2e_pipeline.py            # End-to-end integration tests
+├── conftest.py                     # Pytest fixtures and mocks
+└── README.md                       # This file
+```
+
+## Running Tests
+
+### Run All Tests
+
+```bash
+cd /Users/hemitpatel/PycharmProjects/Next-Voters-Local
+pytest evals/ -v
+```
+
+### Run Specific Test Files
+
+```bash
+# Unit tests for individual components
+pytest evals/test_legislation_finder.py -v
+pytest evals/test_summary_writer.py -v
+pytest evals/test_political_commentary.py -v
+pytest evals/test_report_formatter.py -v
+
+# End-to-end integration tests
+pytest evals/test_e2e_pipeline.py -v
+```
+
+### Run with Coverage
+
+```bash
+pytest evals/ -v --cov=evals --cov-report=html
+```
+
+## Custom Metrics
+
+### Available Metrics
+
+| Metric | File | Purpose |
+|--------|------|---------|
+| `LegislationAccuracyMetric` | `metrics/legislation_accuracy.py` | Measures relevance of discovered legislation to city |
+| `SummaryQualityMetric` | `metrics/summary_quality.py` | Evaluates factual accuracy and completeness of summaries |
+| `PoliticalRelevanceMetric` | `metrics/political_relevance.py` | Measures relevance of political figures to city |
+| `ReportFormattingMetric` | `metrics/report_formatting.py` | Validates markdown report structure |
+| `NoHallucinationMetric` | `metrics/no_hallucination.py` | Detects hallucinated content |
+
+### Using Custom Metrics
+
+```python
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase
+from deepeval import evaluate
+
+from evals.metrics.legislation_accuracy import create_legislation_accuracy_metric
+from evals.metrics.summary_quality import create_summary_quality_metric
+from evals.metrics.report_formatting import create_report_formatting_metric
+
+# Create metrics with custom thresholds
+legislation_metric = create_legislation_accuracy_metric(threshold=0.75)
+summary_metrics = create_summary_quality_metric(threshold=0.8, multi_dimensional=True)
+formatting_metrics = create_report_formatting_metric(threshold=0.7)
+
+# Combine all metrics
+all_metrics = [
+    *legislation_metric,
+    *summary_metrics,
+    *formatting_metrics,
+]
+
+# Create test cases
+test_cases = [
+    LLMTestCase(
+        input="Find Toronto legislation",
+        actual_output="Found Bill 1-2024: Climate Action Initiative",
+        retrieval_context="Source: Toronto City Council\nBill 1-2024 passed 38-7",
+    ),
+]
+
+# Run evaluation
+results = evaluate(test_cases=test_cases, metrics=all_metrics)
+```
+
+### Detailed Metrics
+
+Some metrics have extended versions with sub-scores:
+
+```python
+from evals.metrics.legislation_accuracy import DetailedLegislationAccuracyMetric
+
+metric = DetailedLegislationAccuracyMetric(
+    city_relevance_weight=0.5,
+    legislative_authenticity_weight=0.25,
+    source_credibility_weight=0.25,
+    threshold=0.75,
+)
+```
+
+## Fixtures and Mocks
+
+The `conftest.py` provides fixtures for testing:
+
+### Test Data Fixtures
+
+- `mock_city`: "Toronto"
+- `mock_city_nyc`: "New York City"
+- `mock_city_san_diego`: "San Diego"
+- `sample_legislation_sources`: Toronto legislation sources
+- `sample_legislation_sources_nyc`: NYC legislation sources
+- `sample_legislation_content`: Full legislation text
+- `sample_legislation_notes`: Compressed notes
+- `sample_writer_output`: WriterOutput schema instance
+- `sample_politician_data`: Political figure data
+- `sample_political_statements`: Political statements
+- `sample_markdown_report`: Complete markdown report
+- `mock_retrieval_context`: Source context for evaluation
+
+### Mock API Fixtures
+
+- `mock_brave_search`: Mock Brave Search API responses
+- `mock_wikidata`: Mock Wikidata API responses
+- `mock_llm_response`: Mock LLM responses
+- `mock_structured_llm_response`: Mock structured LLM output
+- `patch_brave_search`: Monkeypatch for Brave Search
+- `patch_wikidata`: Monkeypatch for Wikidata
+
+### State Fixtures
+
+- `mock_agent_state`: Mock agent state for testing
+- `mock_chain_data`: Mock chain data for pipeline testing
+
+## Test Cases
+
+### Legislation Finder Tests
+
+```python
+class TestLegislationFinderAgent:
+    def test_agent_initialization(self)
+    def test_web_search_finds_relevant_sources(self)
+    def test_reliability_analysis_scores_sources(self)
+    def test_full_agent_workflow(self)
+    def test_city_specific_search_queries(self)
+```
+
+### Summary Writer Tests
+
+```python
+class TestSummaryWriter:
+    def test_writer_output_schema_validation(self)
+    def test_summary_writer_produces_valid_schema(self)
+    def test_summary_writer_handles_no_content(self)
+
+class TestSummaryQualityMetric:
+    def test_high_quality_summary(self)
+    def test_incomplete_summary(self)
+    def test_biased_summary(self)
+```
+
+### Political Commentary Tests
+
+```python
+class TestPoliticalCommentaryAgent:
+    def test_agent_initialization(self)
+    def test_political_figure_finder_tool(self)
+    def test_commentary_search_tool(self)
+
+class TestPoliticalRelevanceMetric:
+    def test_highly_relevant_politicians(self)
+    def test_irrelevant_politicians(self)
+```
+
+### Report Formatter Tests
+
+```python
+class TestReportFormatter:
+    def test_formatter_initialization(self)
+    def test_report_formatter_with_valid_input(self)
+    def test_report_includes_required_sections(self)
+
+class TestReportFormattingMetric:
+    def test_well_formatted_report(self)
+    def test_missing_sections(self)
+```
+
+### End-to-End Tests
+
+```python
+class TestEndToEndPipeline:
+    def test_pipeline_produces_markdown_report(self)
+    def test_pipeline_handles_multiple_cities(self)
+
+class TestPipelineIntegration:
+    def test_full_pipeline_with_mocks(self)
+    def test_pipeline_output_quality_metrics(self)
+```
+
+## Scoring Guidelines
+
+### Legislation Accuracy
+
+| Score | Description |
+|-------|-------------|
+| 1.0 | All sources are highly relevant to city and represent actual legislation |
+| 0.8 | Most sources relevant, minor issues |
+| 0.6 | Mixed relevance, some non-municipal sources |
+| 0.4 | Few relevant sources, mostly wrong jurisdiction |
+| 0.0 | No relevant legislation sources found |
+
+### Summary Quality
+
+| Score | Description |
+|-------|-------------|
+| 1.0 | Excellent factual accuracy, completeness, clarity, and objectivity |
+| 0.8 | Minor issues in one dimension |
+| 0.6 | Noticeable issues in 2+ dimensions |
+| 0.4 | Significant gaps in accuracy or completeness |
+| 0.0 | Completely inaccurate or useless summary |
+
+### Political Relevance
+
+| Score | Description |
+|-------|-------------|
+| 1.0 | All figures highly relevant, statements address legislation |
+| 0.8 | Most figures relevant, statements connect to issues |
+| 0.6 | Mixed relevance, some off-topic |
+| 0.4 | Few relevant figures, mostly generic |
+| 0.0 | No relevant figures or statements |
+
+### Report Formatting
+
+| Score | Description |
+|-------|-------------|
+| 1.0 | Perfect structure, all sections present, clean markdown |
+| 0.85 | Minor formatting issues, all sections present |
+| 0.7 | Most sections present, some problems |
+| 0.5 | Missing major sections, formatting issues |
+| 0.0 | Completely unstructured |
+
+## CI/CD Integration
+
+Add to your CI pipeline:
+
+```yaml
+# .github/workflows/eval.yml
+name: Evaluation
+
+on: [push, pull_request]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install deepeval pytest pytest-asyncio pytest-cov
+      
+      - name: Run evaluations
+        run: pytest evals/ -v --tb=short
+        
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: `ModuleNotFoundError: No module named 'deepeval'`
+
+```bash
+pip install deepeval
+```
+
+**Issue**: Mock API calls not working
+
+Ensure you're patching the correct module path. Check imports in the source files.
+
+**Issue**: LLM evaluation is slow
+
+Set `OPENAI_API_KEY` environment variable and consider using `gpt-4o-mini` for faster evaluation.
+
+## Contributing
+
+When adding new tests:
+
+1. Follow the existing test structure in each file
+2. Use fixtures from `conftest.py`
+3. Add appropriate `@pytest.mark` decorators
+4. Include both positive and negative test cases
+5. Test edge cases (empty inputs, special characters, etc.)
+
+## License
+
+Part of NV Local project.

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -1,0 +1,460 @@
+"""Pytest configuration and fixtures for NV Local evaluation suite.
+
+Provides mocks for external APIs (Brave Search, Wikidata, LLM calls)
+to enable isolated unit testing of components.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Generator
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+@pytest.fixture
+def mock_city() -> str:
+    """Standard test city."""
+    return "Toronto"
+
+
+@pytest.fixture
+def mock_city_nyc() -> str:
+    """NYC test city."""
+    return "New York City"
+
+
+@pytest.fixture
+def mock_city_san_diego() -> str:
+    """San Diego test city."""
+    return "San Diego"
+
+
+@pytest.fixture
+def sample_legislation_sources() -> list[dict[str, Any]]:
+    """Sample legislation sources for Toronto."""
+    return [
+        {
+            "url": "https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-1.pdf",
+            "organization": "Toronto City Council",
+            "title": "Bill 1: Climate Action Initiative",
+            "description": "Municipal climate action plan for Toronto 2024-2030",
+            "date": "2024-01-15",
+        },
+        {
+            "url": "https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-2.pdf",
+            "organization": "Toronto City Council",
+            "title": "Bill 2: Affordable Housing Strategy",
+            "description": "New affordable housing requirements for developments",
+            "date": "2024-01-22",
+        },
+        {
+            "url": "https://www.toronto.ca/council/transit-expansion/",
+            "organization": "Toronto Transit Commission",
+            "title": "Transit Expansion Plan 2024",
+            "description": "Ontario Line and other transit improvements",
+            "date": "2024-02-01",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_legislation_sources_nyc() -> list[dict[str, Any]]:
+    """Sample legislation sources for NYC."""
+    return [
+        {
+            "url": "https://legistar.council.nyc.gov/LegislationDetail.aspx?ID=1234567",
+            "organization": "NYC City Council",
+            "title": "Intro 1234: Green New Deal for NYC",
+            "description": "Climate sustainability legislation",
+            "date": "2024-02-15",
+        },
+        {
+            "url": "https://www.nyc.gov/housing-development",
+            "organization": "NYC Department of Housing",
+            "title": "Housing Preservation Plan",
+            "description": "Mandatory inclusionary housing requirements",
+            "date": "2024-01-30",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_legislation_content() -> str:
+    """Sample legislation content for summarization."""
+    return """
+    TORONTO CITY COUNCIL LEGISLATION SUMMARY
+    
+    Bill 1: Climate Action Initiative
+    
+    Date: January 15, 2024
+    Sponsors: Mayor and 15 Council Members
+    
+    Key Provisions:
+    - Target 65% reduction in greenhouse gas emissions by 2030
+    - Mandatory building retrofits for structures over 5,000 sq ft
+    - $50 million annual investment in renewable energy infrastructure
+    - New electric vehicle charging requirements for all new developments
+    - Enhanced tree canopy targets (40% coverage by 2050)
+    
+    Vote: Passed 38-7
+    
+    Bill 2: Affordable Housing Strategy
+    
+    Date: January 22, 2024
+    Sponsors: Housing Committee Chair and 12 Council Members
+    
+    Key Provisions:
+    - Require 20% affordable units in developments over 100 units
+    - Income-based rent control provisions
+    - $100 million housing trust fund
+    - Streamlined approval process for affordable housing projects
+    - Partnerships with non-profit housing providers
+    
+    Vote: Passed 42-3
+    """
+
+
+@pytest.fixture
+def sample_legislation_notes() -> str:
+    """Sample compressed notes from note_taker."""
+    return """
+    CLIMATE ACTION:
+    - 65% GHG reduction target by 2030
+    - Building retrofits mandatory for 5000+ sq ft
+    - $50M renewable energy investment
+    - EV charging in new developments
+    - 40% tree canopy by 2050
+    
+    HOUSING:
+    - 20% affordable units required (100+ unit buildings)
+    - Income-based rent control
+    - $100M housing trust
+    - Streamlined approvals
+    - Non-profit partnerships
+    """
+
+
+@pytest.fixture
+def sample_writer_output() -> dict[str, Any]:
+    """Sample WriterOutput schema."""
+    return {
+        "title": "Toronto City Council Legislation Update - January 2024",
+        "summary": "City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.",
+        "body": """- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030, mandates building retrofits, $50M renewable energy investment
+
+- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units in large developments, establishes $100M housing trust, implements income-based rent control
+
+- **Transit Expansion**: TTC approved Ontario Line expansion plan with federal and provincial funding
+
+- Key themes: Housing affordability and climate sustainability dominate 2024 legislative agenda""",
+    }
+
+
+@pytest.fixture
+def sample_politician_data() -> list[dict[str, Any]]:
+    """Sample political figure data."""
+    return [
+        {
+            "name": "Olivia Chow",
+            "position": "Mayor",
+            "party": None,
+            "jurisdiction": "Toronto",
+            "source_url": "https://www.toronto.ca/mayor/",
+        },
+        {
+            "name": "Josh Matlow",
+            "position": "City Councilor",
+            "party": "Independent",
+            "jurisdiction": "Toronto - Ward 12",
+            "source_url": "https://www.toronto.ca/council/josh-matlow/",
+        },
+        {
+            "name": "Gord Perks",
+            "position": "City Councilor",
+            "party": "New Democrat",
+            "jurisdiction": "Toronto - Ward 4",
+            "source_url": None,
+        },
+    ]
+
+
+@pytest.fixture
+def sample_political_statements() -> list[dict[str, Any]]:
+    """Sample political statements."""
+    return [
+        {
+            "name": "Olivia Chow",
+            "statement_summaries": [
+                {
+                    "source": "https://www.toronto.ca/mayor/news/",
+                    "summary": "Mayor Chow emphasized the climate legislation as a historic step, stating it represents Toronto's commitment to being a leader in municipal climate action.",
+                },
+                {
+                    "source": "https://twitter.com/OliviaChow",
+                    "summary": "On social media, the Mayor highlighted the housing strategy as addressing the core crisis facing Toronto families.",
+                },
+            ],
+        },
+        {
+            "name": "Josh Matlow",
+            "statement_summaries": [
+                {
+                    "source": "https://www.thestar.com/opinion/st -it-by-josh-matlow",
+                    "summary": "Councilor Matlow expressed conditional support for climate bill, noting need for more funding for retrofits in lower-income areas.",
+                },
+            ],
+        },
+    ]
+
+
+@pytest.fixture
+def sample_markdown_report() -> str:
+    """Sample markdown report output."""
+    return """# Toronto City Council Legislation Update - January 2024
+
+## Summary
+
+City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.
+
+## Full Report
+
+- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030, mandates building retrofits, $50M renewable energy investment
+
+- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units in large developments, establishes $100M housing trust, implements income-based rent control
+
+- **Transit Expansion**: TTC approved Ontario Line expansion plan with federal and provincial funding
+
+- Key themes: Housing affordability and climate sustainability dominate 2024 legislative agenda
+
+---
+
+## Politician Public Statements
+### Coming Soon!
+
+### Olivia Chow
+
+**Legislation Source Link:** https://www.toronto.ca/mayor/news/
+
+Mayor Chow emphasized the climate legislation as a historic step, stating it represents Toronto's commitment to being a leader in municipal climate action.
+
+**Legislation Source Link:** https://twitter.com/OliviaChow
+
+On social media, the Mayor highlighted the housing strategy as addressing the core crisis facing Toronto families.
+
+### Josh Matlow
+
+**Legislation Source Link:** https://www.thestar.com/opinion/st -it-by-josh-matlow
+
+Councilor Matlow expressed conditional support for climate bill, noting need for more funding for retrofits in lower-income areas.
+"""
+
+
+@pytest.fixture
+def mock_brave_search() -> MagicMock:
+    """Mock Brave Search API responses."""
+    mock = MagicMock()
+    mock.return_value = {
+        "web": {
+            "results": [
+                {
+                    "title": "Toronto City Council Meeting - January 2024",
+                    "url": "https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-1.pdf",
+                    "description": "Official city council legislation documents",
+                },
+                {
+                    "title": "Toronto Municipal Code - Active Legislation",
+                    "url": "https://www.toronto.ca/legdocs/mmis/2024/",
+                    "description": "Current municipal legislation and bylaws",
+                },
+            ]
+        }
+    }
+    return mock
+
+
+@pytest.fixture
+def mock_wikidata() -> MagicMock:
+    """Mock Wikidata API responses."""
+    mock = MagicMock()
+    mock.return_value = {
+        "results": [
+            {
+                "name": "Olivia Chow",
+                "position": "Mayor of Toronto",
+                "jurisdiction": "Toronto",
+                "type": "human",
+            },
+            {
+                "name": "Toronto City Council",
+                "position": "Legislative body",
+                "jurisdiction": "Toronto",
+                "type": "government organization",
+            },
+        ]
+    }
+    return mock
+
+
+@pytest.fixture
+def mock_llm_response() -> MagicMock:
+    """Mock LLM response."""
+    mock = MagicMock()
+    mock.content = "This is a mock LLM response for testing purposes."
+    return mock
+
+
+@pytest.fixture
+def mock_structured_llm_response() -> dict[str, Any]:
+    """Mock structured LLM response (WriterOutput)."""
+    return {
+        "title": "Toronto City Council Legislation Update",
+        "summary": "Summary of recent legislation.",
+        "body": "Bullet points of legislation details.",
+    }
+
+
+@pytest.fixture
+def mock_agent_state() -> dict[str, Any]:
+    """Mock agent state for testing."""
+    return {
+        "messages": [
+            HumanMessage(content="Find recent legislation for Toronto"),
+            AIMessage(
+                content="I found the following legislation...",
+                tool_calls=[
+                    {
+                        "name": "web_search",
+                        "args": {"query": "Toronto city council legislation 2024"},
+                        "id": "call_123",
+                    }
+                ],
+            ),
+        ],
+        "reflection_list": [],
+        "city": "Toronto",
+        "raw_legislation_sources": [],
+        "reliable_legislation_sources": [],
+    }
+
+
+@pytest.fixture
+def mock_chain_data() -> dict[str, Any]:
+    """Mock chain data for pipeline testing."""
+    return {
+        "city": "Toronto",
+        "legislation_sources": "Sample legislation sources",
+        "notes": sample_legislation_notes(),
+        "legislation_summary": None,
+        "markdown_report": "",
+    }
+
+
+@pytest.fixture
+def mock_retrieval_context() -> str:
+    """Mock retrieval context for evaluation."""
+    return """
+    Source: Toronto City Council Official Website
+    
+    BILL 1-2024: CLIMATE ACTION INITIATIVE
+    
+    Passed: January 15, 2024
+    Vote: 38-7
+    
+    AN ACT TO REDUCE GREENHOUSE GAS EMISSIONS
+    
+    The City of Toronto hereby establishes the following targets:
+    - 65% reduction in GHG emissions by 2030
+    - 100% renewable energy for city operations by 2040
+    
+    Requirements:
+    1. All buildings over 5,000 sq ft must undergo energy audits
+    2. New developments must include EV charging infrastructure
+    3. $50 million annual investment in renewable energy projects
+    
+    BILL 2-2024: AFFORDABLE HOUSING STRATEGY
+    
+    Passed: January 22, 2024
+    Vote: 42-3
+    
+    AN ACT TO ADDRESS HOUSING AFFORDABILITY
+    
+    The City of Toronto establishes:
+    - 20% affordable housing requirement for 100+ unit developments
+    - $100 million Housing Opportunities Reserve Fund
+    - Income-based rent stabilization guidelines
+    """
+
+
+class MockBraveSearchTool:
+    """Mock Brave Search tool for testing."""
+
+    def __init__(self, results: Optional[list[dict]] = None):
+        self.results = results or [
+            {
+                "title": "Test Legislation",
+                "url": "https://example.gov/legislation",
+                "description": "Test description",
+            }
+        ]
+
+    def invoke(self, query: str) -> dict:
+        return {"web": {"results": self.results}}
+
+
+class MockWikidataTool:
+    """Mock Wikidata tool for testing."""
+
+    def __init__(self, entities: Optional[list[dict]] = None):
+        self.entities = entities or [
+            {"name": "Test Politician", "jurisdiction": "Test City"}
+        ]
+
+    def invoke(self, query: str) -> dict:
+        return {"results": self.entities}
+
+
+@pytest.fixture
+def patch_brave_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch Brave Search API for all tests."""
+
+    def mock_search(query: str, **kwargs) -> dict:
+        return {
+            "web": {
+                "results": [
+                    {
+                        "title": f"Legislation related to {query}",
+                        "url": f"https://example.gov/search?q={query}",
+                        "description": "Mock search result",
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr("agents.legislation_finder.web_search.invoke", mock_search)
+
+
+@pytest.fixture
+def patch_wikidata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch Wikidata API for all tests."""
+
+    def mock_find(query: str) -> dict:
+        return {
+            "results": [
+                {
+                    "name": query,
+                    "jurisdiction": "Test City",
+                    "position": "Test Position",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        "agents.political_commentry_finder.political_figure_finder.invoke",
+        mock_find,
+    )
+
+
+from typing import Optional

--- a/evals/metrics/__init__.py
+++ b/evals/metrics/__init__.py
@@ -1,0 +1,15 @@
+"""Custom DeepEval metrics for NV Local evaluation suite."""
+
+from evals.metrics.legislation_accuracy import LegislationAccuracyMetric
+from evals.metrics.summary_quality import SummaryQualityMetric
+from evals.metrics.political_relevance import PoliticalRelevanceMetric
+from evals.metrics.report_formatting import ReportFormattingMetric
+from evals.metrics.no_hallucination import NoHallucinationMetric
+
+__all__ = [
+    "LegislationAccuracyMetric",
+    "SummaryQualityMetric",
+    "PoliticalRelevanceMetric",
+    "ReportFormattingMetric",
+    "NoHallucinationMetric",
+]

--- a/evals/metrics/legislation_accuracy.py
+++ b/evals/metrics/legislation_accuracy.py
@@ -1,0 +1,117 @@
+"""Legislation accuracy metric for NV Local.
+
+Measures if discovered legislation is relevant to the target city
+and represents actual municipal legislation rather than general news.
+"""
+
+from typing import Optional
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCaseParams
+
+
+def legislation_accuracy_criteria() -> str:
+    return """Evaluate whether the discovered legislation sources are:
+    1. Relevant to the specified city/municipality
+    2. Actual municipal/legislative sources (not general news)
+    3. From credible government or legislative websites
+    
+    Score Guidelines:
+    - Score 1.0: All sources are highly relevant to the city and represent actual legislation/ordinances
+    - Score 0.8: Most sources are relevant, minor irrelevant sources present
+    - Score 0.6: Mixed relevance, some non-municipal sources included
+    - Score 0.4: Few relevant sources, mostly general news or wrong jurisdiction
+    - Score 0.2: Almost all sources irrelevant to city or not actual legislation
+    - Score 0.0: No relevant legislation sources found
+
+    Consider:
+    - City name mentions in legislation titles/descriptions
+    - Source domains (gov, council, assembly vs. news sites)
+    - Legislation-specific terms (bill, ordinance, resolution, bylaw, statute)"""
+
+
+LegislationAccuracyMetric = GEval(
+    name="Legislation Accuracy",
+    criteria=legislation_accuracy_criteria(),
+    evaluation_params=[
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+    ],
+    threshold=0.7,
+)
+
+
+class DetailedLegislationAccuracyMetric(GEval):
+    """Extended legislation accuracy metric with detailed sub-scores.
+
+    Provides separate scores for:
+    - City relevance
+    - Legislative authenticity
+    - Source credibility
+    """
+
+    def __init__(
+        self,
+        city_relevance_weight: float = 0.4,
+        legislative_authenticity_weight: float = 0.3,
+        source_credibility_weight: float = 0.3,
+        threshold: float = 0.7,
+    ):
+        self.city_relevance_weight = city_relevance_weight
+        self.legislative_authenticity_weight = legislative_authenticity_weight
+        self.source_credibility_weight = source_credibility_weight
+        super().__init__(
+            name="Detailed Legislation Accuracy",
+            criteria=self._build_detailed_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_detailed_criteria(self) -> str:
+        return f"""Evaluate legislation sources across three dimensions:
+
+    1. City Relevance ({int(self.city_relevance_weight * 100)}%):
+       - Sources mention the target city in title/description
+       - Legislation applies to the city's jurisdiction
+       - Local government bodies are referenced
+    
+    2. Legislative Authenticity ({int(self.legislative_authenticity_weight * 100)}%):
+       - Sources are from actual legislative/government bodies
+       - Content represents bills, ordinances, resolutions, bylaws
+       - Not general news articles about politics
+    
+    3. Source Credibility ({int(self.source_credibility_weight * 100)}%):
+       - Official government domains (gov, .gov, council, assembly)
+       - Established legal/municipal sources
+       - Avoids opinion pieces or advocacy sites
+
+    Provide an overall score 0-1 considering all three dimensions."""
+
+
+def create_legislation_accuracy_metric(
+    threshold: float = 0.7, detailed: bool = False, **kwargs
+) -> GEval:
+    """Factory function to create legislation accuracy metric.
+
+    Args:
+        threshold: Minimum passing score (default: 0.7)
+        detailed: Use detailed metric with sub-scores
+        **kwargs: Additional parameters for detailed metric
+
+    Returns:
+        Configured legislation accuracy metric
+    """
+    if detailed:
+        return DetailedLegislationAccuracyMetric(threshold=threshold, **kwargs)
+    return GEval(
+        name="Legislation Accuracy",
+        criteria=legislation_accuracy_criteria(),
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+        ],
+        threshold=threshold,
+    )

--- a/evals/metrics/no_hallucination.py
+++ b/evals/metrics/no_hallucination.py
@@ -1,0 +1,208 @@
+"""No hallucination metric for NV Local.
+
+Measures if outputs are grounded in source material
+and don't contain hallucinated information.
+"""
+
+from typing import Optional
+
+from deepeval.metrics import GEval, BaseMetric
+from deepeval.test_case import LLMTestCaseParams
+
+
+def no_hallucination_criteria() -> str:
+    return """Evaluate whether the output is grounded in the provided source material:
+
+    1. Factual Grounding:
+       - All factual claims traceable to source material
+       - No invented statistics, dates, or numbers
+       - Proper attribution of quotes and data
+    
+    2. Source Attribution:
+       - Clear when information comes from sources
+       - No claiming unverified information as fact
+       - Appropriate hedging for interpretations
+    
+    3. No Fabrication:
+       - No invented legislation names or numbers
+       - No fake quotes from officials
+       - No invented outcomes or votes
+    
+    4. Contextual Accuracy:
+       - Correct context from source material
+       - No out-of-context quotes or data
+       - Proper handling of ambiguous information
+
+    Score Guidelines:
+    - 1.0: Perfectly grounded, every claim supported by sources
+    - 0.9: Minor overgeneralizations, 1-2 unsupported minor claims
+    - 0.75: Some unsupported claims but generally grounded
+    - 0.5: Noticeable fabrication or unsupported major claims
+    - 0.25: Significant hallucinated content
+    - 0.0: Mostly or completely hallucinated content"""
+
+
+NoHallucinationMetric = GEval(
+    name="No Hallucination",
+    criteria=no_hallucination_criteria(),
+    evaluation_params=[
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+        LLMTestCaseParams.RETRIEVAL_CONTEXT,
+    ],
+    threshold=0.85,
+)
+
+
+class CitationAccuracyMetric(GEval):
+    """Metric specifically for citation accuracy."""
+
+    def __init__(self, threshold: float = 0.9):
+        super().__init__(
+            name="Citation Accuracy",
+            criteria=self._build_citation_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+                LLMTestCaseParams.RETRIEVAL_CONTEXT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_citation_criteria(self) -> str:
+        return """Evaluate accuracy of citations and references:
+
+    Check for:
+    - URLs provided actually exist and are accessible
+    - Document titles match actual documents
+    - Dates cited are correct
+    - Official names are accurate
+    
+    Common hallucinations to detect:
+    - Fake URLs or malformed links
+    - Wrong document titles
+    - Incorrect dates
+    - Misattributed quotes
+    
+    Score 1.0: All citations accurate and verifiable
+    Score 0.8: Minor citation inaccuracies
+    Score 0.6: Some incorrect citations
+    Score 0.4: Many incorrect or fabricated citations
+    Score 0.0: Mostly fabricated citations"""
+
+
+class ClaimVerifiabilityMetric(GEval):
+    """Metric for checking if claims can be verified from context."""
+
+    def __init__(
+        self,
+        verifiable_weight: float = 0.6,
+        contextual_weight: float = 0.4,
+        threshold: float = 0.8,
+    ):
+        self.verifiable_weight = verifiable_weight
+        self.contextual_weight = contextual_weight
+        super().__init__(
+            name="Claim Verifiability",
+            criteria=self._build_verifiability_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+                LLMTestCaseParams.RETRIEVAL_CONTEXT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_verifiability_criteria(self) -> str:
+        return f"""Evaluate whether output claims are verifiable from source context:
+
+    1. Direct Verifiability ({int(self.verifiable_weight * 100)}%):
+       - Claims can be directly confirmed from source material
+       - Numbers, dates, names match sources exactly
+       - Statistics are accurate reproductions
+    
+    2. Contextual Accuracy ({int(self.contextual_weight * 100)}%):
+       - Claims maintain proper context from sources
+       - No out-of-context distortions
+       - Interpretations align with source meaning
+    
+    Score 1.0: All claims verifiable and properly contextualized
+    Score 0.75: Most claims verifiable, minor context issues
+    Score 0.5: Several unverifiable claims or context errors
+    Score 0.25: Many unverifiable claims
+    Score 0.0: Most or all claims cannot be verified"""
+
+
+class HallucinationTypeMetric(GEval):
+    """Detailed metric categorizing types of hallucinations."""
+
+    def __init__(self, threshold: float = 0.8):
+        super().__init__(
+            name="Hallucination Type Analysis",
+            criteria=self._build_hallucination_type_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+                LLMTestCaseParams.RETRIEVAL_CONTEXT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_hallucination_type_criteria(self) -> str:
+        return """Identify and score specific hallucination types:
+
+    Severe Hallucinations (Major deductions):
+    - Fabricated legislation names or numbers
+    - Invented official quotes
+    - Fake voting records or outcomes
+    - Non-existent documents or URLs
+    
+    Moderate Hallucinations:
+    - Slightly incorrect dates or numbers
+    - Misattributed statements
+    - Slightly wrong official names
+    - Inaccurate descriptions of legislation
+    
+    Minor Hallucinations:
+    - Word substitutions that change meaning slightly
+    - Minor context errors
+    - Overgeneralizations from specific facts
+    
+    Scoring:
+    - 1.0: No hallucinations detected
+    - 0.8: Only minor hallucinations
+    - 0.6: 1-2 moderate hallucinations
+    - 0.4: Several moderate hallucinations
+    - 0.2: Any severe hallucinations present
+    - 0.0: Multiple severe hallucinations"""
+
+
+def create_no_hallucination_metric(
+    threshold: float = 0.85,
+    include_citation_check: bool = True,
+    include_verifiability: bool = True,
+    detailed_analysis: bool = False,
+) -> list[GEval]:
+    """Factory function to create no-hallucination metrics.
+
+    Args:
+        threshold: Minimum passing score
+        include_citation_check: Include citation accuracy metric
+        include_verifiability: Include claim verifiability metric
+        detailed_analysis: Include hallucination type analysis
+
+    Returns:
+        List of configured metrics
+    """
+    metrics = [NoHallucinationMetric]
+
+    if include_citation_check:
+        metrics.append(CitationAccuracyMetric())
+
+    if include_verifiability:
+        metrics.append(ClaimVerifiabilityMetric())
+
+    if detailed_analysis:
+        metrics.append(HallucinationTypeMetric())
+
+    return metrics

--- a/evals/metrics/political_relevance.py
+++ b/evals/metrics/political_relevance.py
@@ -1,0 +1,159 @@
+"""Political relevance metric for NV Local.
+
+Measures if political figures and their statements are relevant
+to the target city and its legislative issues.
+"""
+
+from typing import Optional
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCaseParams
+
+
+def political_relevance_criteria() -> str:
+    return """Evaluate political figure and statement relevance:
+
+    1. Geographic Relevance:
+       - Politicians represent or serve the target city/jurisdiction
+       - Statements relate to city-specific issues
+       - Officials from relevant local government bodies
+    
+    2. Topic Relevance:
+       - Statements address legislation being reported on
+       - Comments relate to municipal/urban issues
+       - Position statements on relevant policy matters
+    
+    3. Authority & Credibility:
+       - Figures hold relevant elected/appointed positions
+       - Comments come from official sources or verified accounts
+       - Appropriate balance of perspectives (not just one party)
+    
+    4. Currency:
+       - Statements are recent (within last 1-2 years)
+       - Addresses current legislative session topics
+       - Not outdated or historical commentary
+
+    Score Guidelines:
+    - 1.0: All figures highly relevant, statements directly address legislation
+    - 0.8: Most figures relevant, statements connect to issues
+    - 0.6: Mixed relevance, some figures/statements off-topic
+    - 0.4: Few relevant figures, mostly generic political statements
+    - 0.2: Irrelevant figures or statements not connected to city
+    - 0.0: No relevant political figures or statements found"""
+
+
+PoliticalRelevanceMetric = GEval(
+    name="Political Relevance",
+    criteria=political_relevance_criteria(),
+    evaluation_params=[
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+    ],
+    threshold=0.65,
+)
+
+
+class JurisdictionalRelevanceMetric(GEval):
+    """Metric focused on jurisdictional correctness of political figures."""
+
+    def __init__(self, threshold: float = 0.8):
+        super().__init__(
+            name="Jurisdictional Relevance",
+            criteria=self._build_jurisdictional_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_jurisdictional_criteria(self) -> str:
+        return """Strictly evaluate whether political figures have proper jurisdiction:
+
+    Correct Jurisdiction:
+    - Mayor of the target city
+    - City council members
+    - Local assembly representatives
+    - County officials for the area
+    - State/provincial representatives for the district
+    
+    Incorrect Jurisdiction:
+    - Federal officials (unless city-specific)
+    - Representatives from other cities
+    - International officials
+    - General political commentators without local role
+    
+    Score 1.0: All figures have correct jurisdiction
+    Score 0.8: 1-2 figures slightly off jurisdiction
+    Score 0.5: Multiple figures with wrong jurisdiction
+    Score 0.0: No figures with correct jurisdiction"""
+
+
+class StatementQualityMetric(GEval):
+    """Metric for quality of political statements themselves."""
+
+    def __init__(self, threshold: float = 0.6):
+        super().__init__(
+            name="Statement Quality",
+            criteria=self._build_statement_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_statement_criteria(self) -> str:
+        return """Evaluate the quality of political statements/comments:
+
+    1. Source Quality:
+       - Official statements from verified sources
+       - Credible news outlets with direct quotes
+       - Official social media accounts (verified)
+    
+    2. Content Quality:
+       - Substantive commentary on legislation
+       - Clear positions on issues
+       - Not generic platitudes or non-responses
+    
+    3. Attribution:
+       - Clear who said what
+       - Appropriate use of direct quotes vs summaries
+       - Proper source links provided
+    
+    4. Balance:
+       - Representation of different perspectives
+       - Not one-sided political coverage
+       - Multiple relevant viewpoints included
+
+    Score 1.0: Excellent across all dimensions
+    Score 0.75: Minor issues in one area
+    Score 0.5: Noticeable problems in 2+ areas
+    Score 0.25: Significant quality issues
+    Score 0.0: Useless statement collection"""
+
+
+def create_political_relevance_metric(
+    threshold: float = 0.65,
+    strict_jurisdiction: bool = False,
+    include_statement_quality: bool = True,
+) -> list[GEval]:
+    """Factory function to create political relevance metrics.
+
+    Args:
+        threshold: Minimum passing score
+        strict_jurisdiction: Include strict jurisdictional check
+        include_statement_quality: Include statement quality metric
+
+    Returns:
+        List of configured metrics
+    """
+    metrics = [PoliticalRelevanceMetric]
+
+    if strict_jurisdiction:
+        metrics.append(JurisdictionalRelevanceMetric())
+
+    if include_statement_quality:
+        metrics.append(StatementQualityMetric())
+
+    return metrics

--- a/evals/metrics/report_formatting.py
+++ b/evals/metrics/report_formatting.py
@@ -1,0 +1,167 @@
+"""Report formatting metric for NV Local.
+
+Measures if markdown reports follow expected structure
+and formatting conventions.
+"""
+
+from typing import Optional
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCaseParams
+
+
+def report_formatting_criteria() -> str:
+    return """Evaluate markdown report formatting and structure:
+
+    1. Required Sections Present:
+       - Title section (# header)
+       - Summary section (## Summary)
+       - Full Report section (## Full Report or similar)
+       - Politician Statements section (if applicable)
+    
+    2. Markdown Syntax Correctness:
+       - Proper header hierarchy (H1 > H2 > H3)
+       - Correct bullet point syntax (- or *)
+       - No broken markdown or rendering issues
+       - Consistent formatting throughout
+    
+    3. Content Organization:
+       - Logical flow from summary to details
+       - Clear separation between sections
+       - Easy navigation for readers
+    
+    4. Professional Quality:
+       - Appropriate length for content
+       - Readable formatting (not too dense/sparse)
+       - Consistent styling choices
+
+    Score Guidelines:
+    - 1.0: Perfect structure, all sections present, clean markdown
+    - 0.85: Minor formatting issues, all sections present
+    - 0.7: Most sections present, some formatting problems
+    - 0.5: Missing major sections, noticeable formatting issues
+    - 0.25: Major structural problems
+    - 0.0: Not a valid report or completely unstructured"""
+
+
+ReportFormattingMetric = GEval(
+    name="Report Formatting",
+    criteria=report_formatting_criteria(),
+    evaluation_params=[
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+    ],
+    threshold=0.75,
+)
+
+
+class SectionPresenceMetric(GEval):
+    """Strict metric for required section presence."""
+
+    def __init__(
+        self,
+        required_sections: Optional[list[str]] = None,
+        threshold: float = 1.0,
+    ):
+        self.required_sections = required_sections or [
+            "# Title",
+            "## Summary",
+            "## Full Report",
+            "## Politician",
+        ]
+        super().__init__(
+            name="Section Presence",
+            criteria=self._build_section_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_section_criteria(self) -> str:
+        sections_str = "\n    - ".join(self.required_sections)
+        return f"""Strict evaluation of report section structure.
+
+    Required sections to find in markdown:
+    - {sections_str}
+
+    Scoring:
+    - 1.0: ALL required sections present with correct markdown headers
+    - 0.8: All sections present but minor header formatting issues
+    - 0.6: Missing 1 required section
+    - 0.4: Missing 2 required sections
+    - 0.2: Missing 3 required sections
+    - 0.0: Missing all or most required sections
+    
+    Check specifically for:
+    - # headers for main title
+    - ## headers for major sections
+    - Proper markdown header syntax (# not ## or ### for title)"""
+
+
+class MarkdownSyntaxMetric(GEval):
+    """Metric focused purely on markdown syntax correctness."""
+
+    def __init__(self, threshold: float = 0.9):
+        super().__init__(
+            name="Markdown Syntax",
+            criteria=self._build_syntax_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_syntax_criteria(self) -> str:
+        return """Evaluate only markdown syntax correctness:
+
+    Valid syntax to check:
+    - Headers: # through ###### with space after #
+    - Bold: **text** or __text__
+    - Italic: *text* or _text_
+    - Lists: - or * or 1. with space after marker
+    - Links: [text](url)
+    - Horizontal rules: --- or *** or ___
+    
+    Invalid syntax:
+    - Missing space after # in headers
+    - Unmatched brackets
+    - Broken list formatting
+    - Improper nesting
+    
+    Score 1.0: Perfect markdown syntax throughout
+    Score 0.9: 1-2 minor syntax errors
+    Score 0.75: Several syntax issues that don't break rendering
+    Score 0.5: Multiple syntax errors affecting readability
+    Score 0.25: Extensive syntax problems
+    Score 0.0: Mostly invalid markdown"""
+
+
+def create_report_formatting_metric(
+    threshold: float = 0.75,
+    strict_sections: bool = True,
+    check_syntax: bool = True,
+    required_sections: Optional[list[str]] = None,
+) -> list[GEval]:
+    """Factory function to create report formatting metrics.
+
+    Args:
+        threshold: Minimum passing score
+        strict_sections: Include strict section presence check
+        check_syntax: Include markdown syntax check
+        required_sections: Custom required sections
+
+    Returns:
+        List of configured metrics
+    """
+    metrics = [ReportFormattingMetric]
+
+    if strict_sections:
+        metrics.append(SectionPresenceMetric(required_sections=required_sections))
+
+    if check_syntax:
+        metrics.append(MarkdownSyntaxMetric())
+
+    return metrics

--- a/evals/metrics/summary_quality.py
+++ b/evals/metrics/summary_quality.py
@@ -1,0 +1,169 @@
+"""Summary quality metric for NV Local.
+
+Measures factual accuracy and completeness of summaries
+produced by the SummaryWriter component.
+"""
+
+from typing import Optional
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCaseParams
+
+
+def summary_quality_criteria() -> str:
+    return """Evaluate the quality of the legislation summary across:
+
+    1. Factual Accuracy (Critical):
+       - All factual claims should be verifiable from source material
+       - No hallucinated dates, numbers, or legal references
+       - Correct attribution of legislation to government bodies
+    
+    2. Completeness:
+       - All key legislation mentioned in source material is covered
+       - Important details (dates, sponsors, vote counts) included
+       - No significant gaps in coverage
+    
+    3. Clarity & Structure:
+       - Clear hierarchical organization
+       - Appropriate use of bullet points
+       - Professional tone suitable for voter information
+    
+    4. Objectivity:
+       - Balanced presentation of legislation
+       - No editorializing or political spin
+       - Facts presented neutrally
+
+    Score Guidelines:
+    - 1.0: Excellent across all dimensions
+    - 0.8: Minor issues in one dimension
+    - 0.6: Noticeable issues in 2+ dimensions
+    - 0.4: Significant gaps in accuracy or completeness
+    - 0.2: Major factual errors or missing critical information
+    - 0.0: Completely inaccurate or useless summary"""
+
+
+SummaryQualityMetric = GEval(
+    name="Summary Quality",
+    criteria=summary_quality_criteria(),
+    evaluation_params=[
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+        LLMTestCaseParams.RETRIEVAL_CONTEXT,
+    ],
+    threshold=0.75,
+)
+
+
+class MultiDimensionalSummaryMetric(GEval):
+    """Summary metric with separate dimension scores."""
+
+    def __init__(
+        self,
+        factual_weight: float = 0.4,
+        completeness_weight: float = 0.25,
+        clarity_weight: float = 0.2,
+        objectivity_weight: float = 0.15,
+        threshold: float = 0.75,
+    ):
+        self.factual_weight = factual_weight
+        self.completeness_weight = completeness_weight
+        self.clarity_weight = clarity_weight
+        self.objectivity_weight = objectivity_weight
+        super().__init__(
+            name="Multi-Dimensional Summary Quality",
+            criteria=self._build_multi_dimensional_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+                LLMTestCaseParams.RETRIEVAL_CONTEXT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_multi_dimensional_criteria(self) -> str:
+        return f"""Evaluate summary quality across four weighted dimensions:
+
+    1. Factual Accuracy ({int(self.factual_weight * 100)}%):
+       - Claims verifiable from source material
+       - No hallucinated information
+       - Correct legal references and citations
+    
+    2. Completeness ({int(self.completeness_weight * 100)}%):
+       - All major legislation covered
+       - Key details included (dates, sponsors, outcomes)
+       - No significant coverage gaps
+    
+    3. Clarity & Structure ({int(self.clarity_weight * 100)}%):
+       - Well-organized with clear hierarchy
+       - Appropriate formatting (bullets, sections)
+       - Professional, accessible language
+    
+    4. Objectivity ({int(self.objectivity_weight * 100)}%):
+       - Neutral presentation of facts
+       - No political bias or spin
+       - Balanced coverage of multiple perspectives
+
+    Provide overall weighted score 0-1."""
+
+
+class SchemaComplianceMetric(GEval):
+    """Metric to validate WriterOutput schema compliance."""
+
+    def __init__(self, threshold: float = 1.0):
+        super().__init__(
+            name="Schema Compliance",
+            criteria=self._build_schema_criteria(),
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            threshold=threshold,
+        )
+
+    def _build_schema_criteria(self) -> str:
+        return """Validate that the output strictly follows the WriterOutput schema:
+
+    Required fields:
+    - title: string (non-empty, descriptive title of the legislation)
+    - body: string (main content in bullet-point format)
+    - summary: string (brief summary of the content)
+    
+    Quality requirements:
+    - All three fields must be present
+    - title should be concise but descriptive
+    - body should be in bullet-point format
+    - summary should be 1-3 sentences maximum
+    
+    Score 1.0 only if ALL requirements met.
+    Score 0.5 if minor formatting issues.
+    Score 0.0 if fields missing or fundamentally wrong format."""
+
+
+def create_summary_quality_metric(
+    threshold: float = 0.75,
+    multi_dimensional: bool = False,
+    include_schema_check: bool = True,
+    **kwargs,
+) -> list[GEval]:
+    """Factory function to create summary quality metrics.
+
+    Args:
+        threshold: Minimum passing score
+        multi_dimensional: Use multi-dimensional metric
+        include_schema_check: Include schema compliance metric
+        **kwargs: Additional parameters
+
+    Returns:
+        List of configured metrics
+    """
+    metrics = []
+
+    if multi_dimensional:
+        metrics.append(MultiDimensionalSummaryMetric(threshold=threshold, **kwargs))
+    else:
+        metrics.append(SummaryQualityMetric)
+
+    if include_schema_check:
+        metrics.append(SchemaComplianceMetric())
+
+    return metrics

--- a/evals/test_e2e_pipeline.py
+++ b/evals/test_e2e_pipeline.py
@@ -1,0 +1,436 @@
+"""End-to-end integration tests for NV Local pipeline.
+
+Tests the complete pipeline from legislation discovery
+to final markdown report generation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.test_case import LLMTestCase
+
+from evals.metrics import (
+    LegislationAccuracyMetric,
+    SummaryQualityMetric,
+    PoliticalRelevanceMetric,
+    ReportFormattingMetric,
+    NoHallucinationMetric,
+)
+
+
+class TestEndToEndPipeline:
+    """Test suite for complete NV Local pipeline."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_city: str):
+        self.city = mock_city
+
+    @patch("pipelines.nv_local.chain.invoke")
+    def test_pipeline_produces_markdown_report(
+        self, mock_invoke: MagicMock, sample_markdown_report: str
+    ):
+        """Test that full pipeline produces markdown report."""
+        mock_invoke.return_value = {
+            "city": self.city,
+            "markdown_report": sample_markdown_report,
+        }
+
+        from pipelines.nv_local import run_pipeline
+
+        result = run_pipeline(self.city)
+
+        assert "markdown_report" in result
+        assert isinstance(result["markdown_report"], str)
+        assert len(result["markdown_report"]) > 0
+
+    @patch("pipelines.nv_local.chain.invoke")
+    def test_pipeline_handles_city(self, mock_invoke: MagicMock):
+        """Test pipeline processes city parameter correctly."""
+        mock_invoke.return_value = {
+            "city": self.city,
+            "markdown_report": "# Report",
+        }
+
+        from pipelines.nv_local import run_pipeline
+
+        result = run_pipeline(self.city)
+        assert result["city"] == self.city
+
+    @patch("pipelines.nv_local.chain.invoke")
+    def test_pipeline_handles_multiple_cities(self, mock_invoke: MagicMock):
+        """Test pipeline handles multiple cities."""
+        cities = ["Toronto", "New York City", "San Diego"]
+        mock_invoke.side_effect = [
+            {"city": city, "markdown_report": f"# {city} Report"} for city in cities
+        ]
+
+        from pipelines.nv_local import run_pipelines_for_cities
+
+        results = run_pipelines_for_cities(cities)
+
+        assert len(results) == 3
+        for city in cities:
+            assert city in results
+            assert "markdown_report" in results[city]
+
+
+class TestPipelineComponents:
+    """Test individual pipeline components in integration context."""
+
+    @patch("pipelines.node.legislation_finder.legislation_finder_chain.invoke")
+    def test_legislation_finder_chain(
+        self, mock_invoke: MagicMock, sample_legislation_sources: list[dict]
+    ):
+        """Test legislation finder chain integration."""
+        mock_invoke.return_value = {
+            "city": "Toronto",
+            "legislation_sources": str(sample_legislation_sources),
+        }
+
+        from pipelines.node.legislation_finder import legislation_finder_chain
+
+        result = legislation_finder_chain.invoke({"city": "Toronto"})
+
+        assert "legislation_sources" in result
+
+    @patch("pipelines.node.content_retrieval.content_retrieval_chain.invoke")
+    def test_content_retrieval_chain(self, mock_invoke: MagicMock):
+        """Test content retrieval chain integration."""
+        mock_invoke.return_value = {
+            "city": "Toronto",
+            "legislation_sources": "test sources",
+            "retrieved_content": "retrieved content here",
+        }
+
+        from pipelines.node.content_retrieval import content_retrieval_chain
+
+        result = content_retrieval_chain.invoke(
+            {"city": "Toronto", "legislation_sources": "test"}
+        )
+
+        assert "retrieved_content" in result or "notes" in result
+
+    @patch("pipelines.node.note_taker.note_taker_chain.invoke")
+    def test_note_taker_chain(self, mock_invoke: MagicMock):
+        """Test note taker chain integration."""
+        mock_invoke.return_value = {
+            "city": "Toronto",
+            "notes": "Compressed notes from content",
+        }
+
+        from pipelines.node.note_taker import note_taker_chain
+
+        result = note_taker_chain.invoke(
+            {"city": "Toronto", "retrieved_content": "content"}
+        )
+
+        assert "notes" in result
+
+    @patch("pipelines.node.summary_writer.summary_writer_chain.invoke")
+    def test_summary_writer_chain(
+        self, mock_invoke: MagicMock, sample_writer_output: dict[str, Any]
+    ):
+        """Test summary writer chain integration."""
+        from utils.schemas import WriterOutput
+
+        mock_invoke.return_value = {
+            "city": "Toronto",
+            "notes": "test notes",
+            "legislation_summary": WriterOutput(
+                title=sample_writer_output["title"],
+                summary=sample_writer_output["summary"],
+                body=sample_writer_output["body"],
+            ),
+        }
+
+        from pipelines.node.summary_writer import summary_writer_chain
+
+        result = summary_writer_chain.invoke({"city": "Toronto", "notes": "test"})
+
+        assert "legislation_summary" in result
+
+    @patch("pipelines.node.politician_commentary.politician_commentary_chain.invoke")
+    def test_politician_commentary_chain(
+        self, mock_invoke: MagicMock, sample_political_statements: list[dict]
+    ):
+        """Test politician commentary chain integration."""
+        mock_invoke.return_value = {
+            "city": "Toronto",
+            "politician_public_statements": sample_political_statements,
+        }
+
+        from pipelines.node.politician_commentary import (
+            politician_commentary_chain,
+        )
+
+        result = politician_commentary_chain.invoke({"city": "Toronto"})
+
+        assert "politician_public_statements" in result
+
+    @patch("pipelines.node.report_formatter.report_formatter_chain.invoke")
+    def test_report_formatter_chain(
+        self, mock_invoke: MagicMock, sample_markdown_report: str
+    ):
+        """Test report formatter chain integration."""
+        mock_invoke.return_value = {
+            "city": "Toronto",
+            "markdown_report": sample_markdown_report,
+        }
+
+        from pipelines.node.report_formatter import report_formatter_chain
+        from utils.schemas import WriterOutput
+
+        result = report_formatter_chain.invoke(
+            {
+                "legislation_summary": WriterOutput(
+                    title="Test", summary="Test", body="Test"
+                ),
+                "politician_public_statements": [],
+            }
+        )
+
+        assert "markdown_report" in result
+
+
+class TestPipelineErrorHandling:
+    """Test pipeline error handling."""
+
+    @patch("pipelines.node.legislation_finder.legislation_finder_chain.invoke")
+    def test_pipeline_handles_legislation_finder_error(self, mock_invoke: MagicMock):
+        """Test pipeline handles legislation finder errors."""
+        mock_invoke.side_effect = Exception("Search API error")
+
+        from pipelines.nv_local import run_pipeline
+
+        result = run_pipeline("Toronto")
+
+        assert "error" in result or "markdown_report" in result
+
+    @patch("pipelines.node.summary_writer.summary_writer_chain.invoke")
+    def test_pipeline_handles_summary_writer_error(self, mock_invoke: MagicMock):
+        """Test pipeline handles summary writer errors."""
+        mock_invoke.side_effect = Exception("LLM error")
+
+        from pipelines.nv_local import run_pipeline
+
+        result = run_pipeline("Toronto")
+
+        assert "error" in result or "markdown_report" in result
+
+
+class TestPipelineOutput:
+    """Test pipeline output quality."""
+
+    def test_report_contains_expected_structure(self, sample_markdown_report: str):
+        """Test that report has expected markdown structure."""
+        assert "# " in sample_markdown_report
+        assert "## " in sample_markdown_report
+        assert sample_markdown_report.count("#") >= 2
+
+    def test_report_contains_politician_section(self, sample_markdown_report: str):
+        """Test that report contains politician statements section."""
+        assert "Politician" in sample_markdown_report
+        assert (
+            "Coming Soon" in sample_markdown_report or "###" in sample_markdown_report
+        )
+
+
+class TestPipelineIntegration:
+    """Full integration tests for pipeline."""
+
+    @patch("agents.political_commentry_finder.political_commentry_agent.invoke")
+    @patch("pipelines.node.summary_writer.model.invoke")
+    @patch("tools.legislation_finder.web_search.invoke")
+    def test_full_pipeline_with_mocks(
+        self,
+        mock_search: MagicMock,
+        mock_llm: MagicMock,
+        mock_political: MagicMock,
+        sample_legislation_sources: list[dict],
+        sample_writer_output: dict[str, Any],
+        sample_political_statements: list[dict],
+    ):
+        """Test complete pipeline with all mocks."""
+        from utils.schemas import WriterOutput
+
+        mock_search.return_value = {
+            "web": {"results": [{"title": "Test", "url": "https://test.com"}]}
+        }
+        mock_llm.return_value = WriterOutput(
+            title=sample_writer_output["title"],
+            summary=sample_writer_output["summary"],
+            body=sample_writer_output["body"],
+        )
+        mock_political.return_value = {
+            "political_commentary": [],
+            "political_figures": [],
+        }
+
+        from pipelines.nv_local import run_pipeline
+
+        result = run_pipeline("Toronto")
+
+        assert result is not None
+        assert "markdown_report" in result or "error" in result
+
+    def test_pipeline_output_quality_metrics(self, sample_markdown_report: str):
+        """Test report quality using evaluation metrics."""
+        test_case = LLMTestCase(
+            input="Full pipeline for Toronto legislation",
+            actual_output=sample_markdown_report,
+            retrieval_context="""
+            Source: Toronto City Council
+            Bill 1-2024: Climate Action Initiative (65% GHG reduction)
+            Bill 2-2024: Affordable Housing Strategy (20% affordable units)
+            """,
+        )
+
+        metrics = [
+            ReportFormattingMetric,
+            NoHallucinationMetric,
+        ]
+
+        for metric in metrics:
+            metric.measure(test_case)
+            assert metric.score >= 0
+
+
+class TestSupportedCities:
+    """Test pipeline with supported cities."""
+
+    @pytest.mark.parametrize("city", ["Toronto", "New York City", "San Diego"])
+    @patch("pipelines.nv_local.chain.invoke")
+    def test_supported_cities(self, mock_invoke: MagicMock, city: str):
+        """Test pipeline with each supported city."""
+        from data import SUPPORTED_CITIES
+
+        assert city in SUPPORTED_CITIES
+
+        mock_invoke.return_value = {
+            "city": city,
+            "markdown_report": f"# {city} Report",
+        }
+
+        from pipelines.nv_local import run_pipeline
+
+        result = run_pipeline(city)
+
+        assert result["city"] == city
+
+
+class TestPipelineRendering:
+    """Test pipeline output rendering."""
+
+    @patch("pipelines.nv_local.run_pipelines_for_cities")
+    def test_render_city_reports(
+        self,
+        mock_run: MagicMock,
+        sample_markdown_report: str,
+    ):
+        """Test rendering multiple city reports."""
+        mock_run.return_value = {
+            "Toronto": {"markdown_report": sample_markdown_report},
+            "NYC": {"markdown_report": "# NYC Report"},
+        }
+
+        from pipelines.nv_local import render_city_reports_markdown
+
+        result = render_city_reports_markdown(mock_run.return_value)
+
+        assert "## Toronto" in result
+        assert "## NYC" in result
+
+    @patch("pipelines.nv_local.run_pipelines_for_cities")
+    def test_render_with_errors(self, mock_run: MagicMock):
+        """Test rendering with pipeline errors."""
+        mock_run.return_value = {
+            "Toronto": {
+                "error": "Test error",
+                "markdown_report": "",
+            },
+        }
+
+        from pipelines.nv_local import render_city_reports_markdown
+
+        result = render_city_reports_markdown(mock_run.return_value)
+
+        assert "**Error:**" in result
+
+
+def run_e2e_evaluation() -> dict[str, Any]:
+    """Run full end-to-end evaluation suite.
+
+    Returns:
+        Dictionary with evaluation results
+    """
+    from deepeval import evaluate
+
+    test_cases = [
+        LLMTestCase(
+            input="Run full NV Local pipeline for Toronto",
+            actual_output="""# Toronto City Council Legislation Update - January 2024
+
+## Summary
+City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.
+
+## Full Report
+- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030
+- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units
+
+---
+
+## Politician Public Statements
+### Coming Soon!
+
+### Olivia Chow
+Mayor Chow emphasized the climate legislation as a historic step.""",
+            retrieval_context="""
+            Source: Toronto City Council
+            Bill 1-2024: Climate Action Initiative
+            - 65% GHG reduction by 2030
+            - Passed 38-7
+            
+            Bill 2-2024: Affordable Housing Strategy
+            - 20% affordable units
+            - Passed 42-3
+            """,
+        ),
+        LLMTestCase(
+            input="Run full pipeline for NYC",
+            actual_output="""# NYC City Council Update
+
+## Summary
+City Council passed Green New Deal legislation.
+
+## Full Report
+- Intro 1234: Climate legislation passed
+- Housing preservation laws updated
+
+## Politician Statements
+### Coming Soon!""",
+            retrieval_context="""
+            Source: NYC City Council
+            Intro 1234: Green New Deal for NYC
+            Housing Preservation Plan
+            """,
+        ),
+    ]
+
+    metrics = [
+        LegislationAccuracyMetric,
+        SummaryQualityMetric,
+        PoliticalRelevanceMetric,
+        ReportFormattingMetric,
+        NoHallucinationMetric,
+    ]
+
+    results = evaluate(test_cases=test_cases, metrics=metrics)
+    return results
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/evals/test_legislation_finder.py
+++ b/evals/test_legislation_finder.py
@@ -1,0 +1,306 @@
+"""Unit tests for LegislationFinderAgent.
+
+Tests the agent's ability to find relevant municipal legislation
+and analyze source reliability.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase
+from deepeval import evaluate
+
+from evals.metrics.legislation_accuracy import (
+    LegislationAccuracyMetric,
+    create_legislation_accuracy_metric,
+)
+from evals.metrics.no_hallucination import NoHallucinationMetric
+
+
+class TestLegislationFinderAgent:
+    """Test suite for LegislationFinderAgent component."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_city: str, sample_legislation_sources: list[dict]):
+        self.city = mock_city
+        self.sample_sources = sample_legislation_sources
+
+    def test_agent_initialization(self):
+        """Test that agent can be instantiated."""
+        from agents.legislation_finder import legislation_finder_agent
+
+        assert legislation_finder_agent is not None
+        assert hasattr(legislation_finder_agent, "invoke")
+
+    @patch("agents.legislation_finder.web_search.invoke")
+    def test_web_search_finds_relevant_sources(
+        self, mock_search: MagicMock, sample_legislation_sources: list[dict]
+    ):
+        """Test that web search returns relevant legislation sources."""
+        mock_search.return_value = {
+            "web": {
+                "results": [
+                    {
+                        "title": src["title"],
+                        "url": src["url"],
+                        "description": src["description"],
+                    }
+                    for src in sample_legislation_sources
+                ]
+            }
+        }
+
+        from tools.legislation_finder import web_search
+
+        result = web_search.invoke(f"{self.city} city council legislation 2024")
+
+        assert "web" in result
+        assert len(result["web"]["results"]) == 3
+        assert all(
+            self.city in r["title"] or self.city in r["description"]
+            for r in result["web"]["results"]
+        )
+
+    @patch("tools.legislation_finder.reliability_analysis.invoke")
+    def test_reliability_analysis_scores_sources(self, mock_reliability: MagicMock):
+        """Test that reliability analysis assigns scores to sources."""
+        mock_reliability.return_value = {
+            "analyses": [
+                {
+                    "url": "https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-1.pdf",
+                    "reliability_score": 0.95,
+                    "reasoning": "Official city government source",
+                },
+                {
+                    "url": "https://www.thestar.com/toronto/legislation",
+                    "reliability_score": 0.7,
+                    "reasoning": "Established news source but not primary",
+                },
+            ]
+        }
+
+        from tools.legislation_finder import reliability_analysis
+
+        sources = [
+            {
+                "url": "https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-1.pdf"
+            },
+            {"url": "https://www.thestar.com/toronto/legislation"},
+        ]
+        result = reliability_analysis.invoke({"sources": sources})
+
+        assert "analyses" in result
+        assert len(result["analyses"]) == 2
+        assert all("reliability_score" in a for a in result["analyses"])
+
+
+class TestLegislationAccuracyMetric:
+    """Test suite for legislation accuracy evaluation metric."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.metric = create_legislation_accuracy_metric(threshold=0.7)
+
+    def test_metric_with_relevant_sources(self):
+        """Test metric scores highly for relevant sources."""
+        test_case = LLMTestCase(
+            input="Find recent legislation for Toronto",
+            actual_output="""Found the following legislation:
+            1. Toronto City Council Bill 1-2024: Climate Action Initiative
+               URL: https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-1.pdf
+            2. Toronto Municipal Code Amendment: Affordable Housing
+               URL: https://www.toronto.ca/legdocs/mmis/2024/
+            """,
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score >= 0.7
+        assert self.metric.reason is not None
+
+    def test_metric_with_irrelevant_sources(self):
+        """Test metric scores low for irrelevant sources."""
+        test_case = LLMTestCase(
+            input="Find recent legislation for Toronto",
+            actual_output="""Found the following:
+            1. Federal Budget 2024 (irrelevant)
+            2. US Senate Bill (wrong country)
+            3. General news article
+            """,
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score < 0.7
+
+    def test_metric_with_mixed_relevance(self):
+        """Test metric with mixed relevance sources."""
+        test_case = LLMTestCase(
+            input="Find recent legislation for Toronto",
+            actual_output="""Found:
+            1. Toronto Climate Action Bill (relevant, government source)
+            2. Toronto Star news article about provincial politics (somewhat relevant)
+            3. NYC legislation (irrelevant)
+            """,
+        )
+
+        self.metric.measure(test_case)
+        assert 0.4 <= self.metric.score <= 0.8
+
+    def test_detailed_metric_initialization(self):
+        """Test detailed metric can be created."""
+        from evals.metrics.legislation_accuracy import DetailedLegislationAccuracyMetric
+
+        detailed_metric = DetailedLegislationAccuracyMetric(
+            city_relevance_weight=0.5,
+            legislative_authenticity_weight=0.25,
+            source_credibility_weight=0.25,
+            threshold=0.75,
+        )
+
+        assert detailed_metric.city_relevance_weight == 0.5
+        assert detailed_metric.legislative_authenticity_weight == 0.25
+        assert detailed_metric.source_credibility_weight == 0.25
+
+
+class TestLegislationFinderIntegration:
+    """Integration tests for legislation finder workflow."""
+
+    @patch("agents.legislation_finder.legislation_finder_agent.invoke")
+    def test_full_agent_workflow(
+        self,
+        mock_invoke: MagicMock,
+        mock_city: str,
+        sample_legislation_sources: list[dict],
+    ):
+        """Test complete agent workflow from query to sources."""
+        mock_invoke.return_value = {
+            "city": mock_city,
+            "reliable_legislation_sources": [
+                src["url"] for src in sample_legislation_sources[:2]
+            ],
+            "messages": [],
+        }
+
+        from agents.legislation_finder import legislation_finder_agent
+
+        result = legislation_finder_agent.invoke({"city": mock_city})
+
+        assert "reliable_legislation_sources" in result
+        assert len(result["reliable_legislation_sources"]) >= 1
+
+    def test_city_specific_search_queries(self):
+        """Test that search queries are city-specific."""
+        from agents.legislation_finder import legislation_finder_agent
+
+        test_cases = [
+            ("Toronto", "Toronto"),
+            ("New York City", "New York City"),
+            ("San Diego", "San Diego"),
+        ]
+
+        for city, expected_in_query in test_cases:
+            state = {"city": city, "messages": [], "reflection_list": []}
+            from agents.legislation_finder import legislation_finder_sys_prompt
+            from datetime import datetime, timedelta
+
+            prompt = legislation_finder_sys_prompt.format(
+                input_city=city,
+                last_week_date=(datetime.today() - timedelta(days=7)).strftime(
+                    "%B %d, %Y"
+                ),
+                today=datetime.today().strftime("%B %d, %Y"),
+            )
+            assert expected_in_query in prompt
+
+
+class TestLegislationFinderEdgeCases:
+    """Edge case tests for legislation finder."""
+
+    def test_empty_city_handling(self):
+        """Test handling of empty city input."""
+        from agents.legislation_finder import legislation_finder_agent
+
+        result = legislation_finder_agent.invoke({"city": ""})
+        assert result is not None
+
+    def test_no_legislation_found(self):
+        """Test handling when no legislation is found."""
+        with patch("tools.legislation_finder.web_search.invoke") as mock_search:
+            mock_search.return_value = {"web": {"results": []}}
+
+            from tools.legislation_finder import web_search
+
+            result = web_search.invoke("nonexistent city xyz123 legislation")
+            assert result["web"]["results"] == []
+
+    def test_invalid_source_urls(self):
+        """Test handling of invalid source URLs."""
+        with patch("tools.legislation_finder.reliability_analysis.invoke") as mock:
+            mock.return_value = {
+                "analyses": [
+                    {
+                        "url": "not-a-valid-url",
+                        "reliability_score": 0.0,
+                        "reasoning": "Invalid URL format",
+                    }
+                ]
+            }
+
+            from tools.legislation_finder import reliability_analysis
+
+            result = reliability_analysis.invoke(
+                {"sources": [{"url": "not-a-valid-url"}]}
+            )
+            assert result["analyses"][0]["reliability_score"] == 0.0
+
+
+def run_legislation_finder_evaluation() -> dict[str, Any]:
+    """Run full evaluation suite for legislation finder.
+
+    Returns:
+        Dictionary with evaluation results
+    """
+    test_cases = [
+        LLMTestCase(
+            input="Find recent legislation for Toronto",
+            actual_output="""Toronto City Council legislation found:
+            1. Bill 1-2024: Climate Action Initiative
+               Source: https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-1.pdf
+               (Official Toronto government source)
+            2. Bill 2-2024: Affordable Housing Strategy
+               Source: https://www.toronto.ca/legdocs/mmis/2024/cc/billd -it/2024-cc-doc-2.pdf
+               (Official Toronto government source)""",
+        ),
+        LLMTestCase(
+            input="Find recent legislation for NYC",
+            actual_output="""NYC legislation found:
+            1. Intro 1234: Green New Deal for NYC
+               Source: https://legistar.council.nyc.gov/LegislationDetail.aspx?ID=1234567
+               (Official NYC City Council source)
+            2. Local Law 45: Housing Preservation
+               Source: https://www.nyc.gov/housing-development""",
+        ),
+        LLMTestCase(
+            input="Find recent legislation for Toronto",
+            actual_output="""Found some general news:
+            - Federal elections coming up
+            - Provincial budget discussions
+            - Some random article about Toronto sports""",
+        ),
+    ]
+
+    metrics = [
+        create_legislation_accuracy_metric(threshold=0.7),
+        NoHallucinationMetric,
+    ]
+
+    results = evaluate(test_cases=test_cases, metrics=metrics)
+    return results
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/evals/test_political_commentary.py
+++ b/evals/test_political_commentary.py
@@ -1,0 +1,373 @@
+"""Unit tests for PoliticalCommentaryAgent.
+
+Tests the agent's ability to find relevant political figures
+and their public statements on municipal legislation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.test_case import LLMTestCase
+
+from evals.metrics.political_relevance import (
+    PoliticalRelevanceMetric,
+    JurisdictionalRelevanceMetric,
+    StatementQualityMetric,
+    create_political_relevance_metric,
+)
+from utils.schemas import PoliticalCommentaryState, PoliticalFigure
+
+
+class TestPoliticalCommentaryAgent:
+    """Test suite for PoliticalCommentaryAgent component."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        mock_city: str,
+        sample_politician_data: list[dict],
+        sample_political_statements: list[dict],
+    ):
+        self.city = mock_city
+        self.politician_data = sample_politician_data
+        self.statements = sample_political_statements
+
+    def test_agent_initialization(self):
+        """Test that agent can be instantiated."""
+        from agents.political_commentry_finder import political_commentry_agent
+
+        assert political_commentry_agent is not None
+        assert hasattr(political_commentry_agent, "invoke")
+
+    def test_political_figure_schema(self):
+        """Test PoliticalFigure schema validation."""
+        figure = PoliticalFigure(
+            name="Test Politician",
+            position="Mayor",
+            party="Test Party",
+            jurisdiction="Test City",
+            source_url="https://example.gov",
+        )
+
+        assert figure.name == "Test Politician"
+        assert figure.position == "Mayor"
+        assert figure.jurisdiction == "Test City"
+
+    @patch("agents.political_commentry_finder.political_commentry_agent.invoke")
+    def test_agent_finds_politicians(
+        self,
+        mock_invoke: MagicMock,
+        mock_city: str,
+        sample_politician_data: list[dict],
+    ):
+        """Test that agent finds relevant political figures."""
+        mock_invoke.return_value = {
+            "city": mock_city,
+            "political_figures": sample_politician_data,
+            "political_commentary": [],
+        }
+
+        from agents.political_commentry_finder import political_commentry_agent
+
+        result = political_commentry_agent.invoke({"city": mock_city})
+
+        assert "political_figures" in result
+        assert len(result["political_figures"]) >= 1
+
+    @patch("tools.political_commentry_finder.political_figure_finder.invoke")
+    def test_political_figure_finder_tool(
+        self, mock_find: MagicMock, sample_politician_data: list[dict]
+    ):
+        """Test political figure finder tool."""
+        mock_find.return_value = {"results": self.politician_data}
+
+        from tools.political_commentry_finder import political_figure_finder
+
+        result = political_figure_finder.invoke(f"Political figures in {self.city}")
+
+        assert "results" in result
+        assert len(result["results"]) == 3
+
+    @patch("tools.political_commentry_finder.search_political_commentary.invoke")
+    def test_commentary_search_tool(
+        self, mock_search: MagicMock, sample_political_statements: list[dict]
+    ):
+        """Test political commentary search tool."""
+        mock_search.return_value = {"results": self.statements}
+
+        from tools.political_commentry_finder import search_political_commentary
+
+        result = search_political_commentary.invoke("Olivia Chow statements on housing")
+
+        assert "results" in result
+
+
+class TestPoliticalRelevanceMetric:
+    """Test suite for political relevance evaluation metric."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.metric = PoliticalRelevanceMetric
+
+    def test_highly_relevant_politicians(self):
+        """Test metric scores high for relevant political figures."""
+        test_case = LLMTestCase(
+            input="Find political figures commenting on Toronto housing legislation",
+            actual_output="""Political figures and statements:
+
+1. Olivia Chow, Mayor of Toronto
+   - Statement: "This housing legislation represents our commitment to Toronto families"
+   - Source: Toronto Mayor's Office press release
+
+2. Josh Matlow, City Councilor (Ward 12)
+   - Statement: "While supportive, we need more funding for affordable units"
+   - Source: Toronto Star op-ed
+
+3. Jennifer Veen, City Councilor (Ward 9)
+   - Statement: "Will vote yes on Bill 2-2024"
+   - Source: Council meeting minutes""",
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score >= 0.65
+        assert self.metric.reason is not None
+
+    def test_irrelevant_politicians(self):
+        """Test metric scores low for irrelevant figures."""
+        test_case = LLMTestCase(
+            input="Find political figures commenting on Toronto housing",
+            actual_output="""Relevant figures:
+
+1. President Biden - Federal politics, not Toronto
+2. Premier Ford - Ontario Premier, not direct Toronto jurisdiction
+3. Celebrity chef commenting on food trends""",
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score < 0.5
+
+    def test_mixed_relevance(self):
+        """Test metric with mixed relevance."""
+        test_case = LLMTestCase(
+            input="Find political figures on Toronto climate legislation",
+            actual_output="""Found:
+
+1. Olivia Chow (Mayor of Toronto) - Directly relevant ✓
+2. Premier Ford - Somewhat relevant (provincial oversight) △
+3. Random political blogger - Not relevant ✗""",
+        )
+
+        self.metric.measure(test_case)
+        assert 0.3 <= self.metric.score <= 0.7
+
+
+class TestJurisdictionalRelevanceMetric:
+    """Test suite for jurisdictional relevance validation."""
+
+    def test_correct_jurisdiction(self):
+        """Test that correct jurisdiction scores high."""
+        metric = JurisdictionalRelevanceMetric(threshold=0.8)
+
+        test_case = LLMTestCase(
+            input="Political figures for Toronto",
+            actual_output="""Politicians with correct jurisdiction:
+1. Olivia Chow - Mayor of Toronto ✓
+2. Gord Perks - Toronto City Councilor ✓
+3. Mike Layton - Former Toronto Councilor ✓""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score >= 0.8
+
+    def test_incorrect_jurisdiction(self):
+        """Test that incorrect jurisdiction scores low."""
+        metric = JurisdictionalRelevanceMetric(threshold=0.8)
+
+        test_case = LLMTestCase(
+            input="Political figures for Toronto",
+            actual_output="""Politicians found:
+1. Justin Trudeau - Canadian Prime Minister (federal) ✗
+2. Kathy Hochul - NY Governor (wrong jurisdiction) ✗
+3. Generic political commentator ✗""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score < 0.5
+
+
+class TestStatementQualityMetric:
+    """Test suite for statement quality evaluation."""
+
+    def test_high_quality_statements(self):
+        """Test metric scores high for quality statements."""
+        metric = StatementQualityMetric(threshold=0.6)
+
+        test_case = LLMTestCase(
+            input="Political statements on Toronto housing Bill 2-2024",
+            actual_output="""Statement 1: Mayor Olivia Chow
+"Bill 2-2024 represents a transformative step for housing affordability in Toronto. 
+The 20% affordable housing requirement will create thousands of units for families 
+who have been priced out of our market."
+Source: Mayor's Office official press release (January 22, 2024)
+
+Statement 2: Councilor Josh Matlow
+"I support the intent of Bill 2-2024, but we need to ensure the $100M housing 
+trust includes dedicated funding for deep affordable units serving those 
+earning below $40,000 annually."
+Source: Toronto Star op-ed, January 23, 2024""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score >= 0.6
+
+    def test_low_quality_statements(self):
+        """Test metric detects low quality statements."""
+        metric = StatementQualityMetric(threshold=0.6)
+
+        test_case = LLMTestCase(
+            input="Political statements on housing",
+            actual_output="""Some politicians said stuff about housing maybe.""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score < 0.4
+
+
+class TestPoliticalCommentaryIntegration:
+    """Integration tests for political commentary workflow."""
+
+    @patch("agents.political_commentry_finder.political_commentry_agent.invoke")
+    def test_full_workflow(
+        self,
+        mock_invoke: MagicMock,
+        mock_city: str,
+        sample_politician_data: list[dict],
+        sample_political_statements: list[dict],
+    ):
+        """Test complete political commentary workflow."""
+        mock_invoke.return_value = {
+            "city": mock_city,
+            "political_figures": sample_politician_data,
+            "political_commentary": [
+                {
+                    "politician": "Olivia Chow",
+                    "source_url": "https://example.com",
+                    "comment": "Statement on legislation",
+                }
+            ],
+        }
+
+        from agents.political_commentry_finder import political_commentry_agent
+
+        result = political_commentry_agent.invoke({"city": mock_city})
+
+        assert "political_figures" in result
+        assert "political_commentary" in result
+
+    def test_city_specific_queries(self):
+        """Test that queries are city-specific."""
+        test_cases = [
+            ("Toronto", "Toronto"),
+            ("New York City", "New York"),
+            ("San Diego", "San Diego"),
+        ]
+
+        for city, expected in test_cases:
+            from config.system_prompts import political_commentry_sys_prompt
+
+            assert expected in political_commentry_sys_prompt
+
+
+class TestPoliticalCommentaryEdgeCases:
+    """Edge case tests for political commentary."""
+
+    def test_no_politicians_found(self):
+        """Test handling when no politicians are found."""
+        with patch(
+            "tools.political_commentry_finder.political_figure_finder.invoke"
+        ) as mock:
+            mock.return_value = {"results": []}
+
+            from tools.political_commentry_finder import political_figure_finder
+
+            result = political_figure_finder.invoke("Nonexistent City Politicians")
+            assert result["results"] == []
+
+    def test_politician_without_party(self):
+        """Test handling of politicians without party affiliation."""
+        figure = PoliticalFigure(
+            name="Independent Politician",
+            position="Mayor",
+            jurisdiction="Test City",
+        )
+
+        assert figure.party is None
+        assert figure.name == "Independent Politician"
+
+    def test_empty_statements(self):
+        """Test handling of empty statements."""
+        with patch(
+            "tools.political_commentry_finder.search_political_commentary.invoke"
+        ) as mock:
+            mock.return_value = {"results": []}
+
+            from tools.political_commentry_finder import search_political_commentary
+
+            result = search_political_commentary.invoke("Politician statements")
+            assert result["results"] == []
+
+
+def run_political_commentary_evaluation() -> dict[str, Any]:
+    """Run full evaluation suite for political commentary.
+
+    Returns:
+        Dictionary with evaluation results
+    """
+    from deepeval import evaluate
+
+    test_cases = [
+        LLMTestCase(
+            input="Find political figures commenting on Toronto climate legislation",
+            actual_output="""Political figures and statements:
+
+1. Olivia Chow, Mayor of Toronto
+   - "The Climate Action Initiative represents Toronto's commitment to our 
+     future. The 65% reduction target is ambitious but achievable."
+   - Source: Mayor's official statement, January 15, 2024
+
+2. Gord Perks, City Councilor (Ward 4)
+   - "I've long advocated for building retrofits. This bill finally delivers 
+     the policy framework we've needed."
+   - Source: Council meeting, January 15, 2024
+
+3. Jennifer Veen, City Councilor (Ward 9)
+   - "Concerned about implementation timeline and funding for lower-income 
+     areas. Will propose amendments."
+   - Source: Twitter/X statement, January 16, 2024""",
+        ),
+        LLMTestCase(
+            input="Find political commentary on Toronto housing",
+            actual_output="""Found:
+
+1. Some mayor said something about housing
+2. Maybe a councilor too
+3. (Not very specific or verifiable)""",
+        ),
+    ]
+
+    metrics = create_political_relevance_metric(
+        threshold=0.65,
+        strict_jurisdiction=True,
+        include_statement_quality=True,
+    )
+
+    results = evaluate(test_cases=test_cases, metrics=metrics)
+    return results
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/evals/test_report_formatter.py
+++ b/evals/test_report_formatter.py
@@ -1,0 +1,530 @@
+"""Unit tests for ReportFormatter component.
+
+Tests the formatter's ability to create well-structured
+markdown reports from summaries and political statements.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.test_case import LLMTestCase
+
+from evals.metrics.report_formatting import (
+    ReportFormattingMetric,
+    SectionPresenceMetric,
+    MarkdownSyntaxMetric,
+    create_report_formatting_metric,
+)
+from utils.schemas import ChainData, WriterOutput
+
+
+class TestReportFormatter:
+    """Test suite for ReportFormatter component."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        sample_writer_output: dict[str, Any],
+        sample_political_statements: list[dict],
+    ):
+        self.summary = sample_writer_output
+        self.statements = sample_political_statements
+
+    def test_formatter_initialization(self):
+        """Test that formatter can be imported."""
+        from pipelines.node.report_formatter import report_formatter_chain
+
+        assert report_formatter_chain is not None
+
+    def test_report_formatter_with_valid_input(
+        self,
+        sample_writer_output: dict[str, Any],
+        sample_political_statements: list[dict],
+    ):
+        """Test report formatter with valid inputs."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title=sample_writer_output["title"],
+                summary=sample_writer_output["summary"],
+                body=sample_writer_output["body"],
+            ),
+            "politician_public_statements": sample_political_statements,
+        }
+
+        result = report_formatter(inputs)
+
+        assert "markdown_report" in result
+        assert isinstance(result["markdown_report"], str)
+        assert len(result["markdown_report"]) > 0
+
+    def test_report_formatter_without_summary(self):
+        """Test report formatter handles missing summary gracefully."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": None,
+            "politician_public_statements": [],
+        }
+
+        result = report_formatter(inputs)
+
+        assert "markdown_report" in result
+        assert "No Legislation Found" in result["markdown_report"]
+
+    def test_report_formatter_without_politicians(
+        self, sample_writer_output: dict[str, Any]
+    ):
+        """Test report formatter handles missing political statements."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title=sample_writer_output["title"],
+                summary=sample_writer_output["summary"],
+                body=sample_writer_output["body"],
+            ),
+            "politician_public_statements": [],
+        }
+
+        result = report_formatter(inputs)
+
+        assert "markdown_report" in result
+        assert "# " in result["markdown_report"]
+
+    def test_report_includes_required_sections(
+        self, sample_writer_output: dict[str, Any]
+    ):
+        """Test that report includes all required sections."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title="Test Title",
+                summary="Test summary",
+                body="Test body content",
+            ),
+            "politician_public_statements": [
+                {
+                    "name": "Test Politician",
+                    "statement_summaries": [
+                        {"source": "https://example.com", "summary": "Test statement"}
+                    ],
+                }
+            ],
+        }
+
+        result = report_formatter(inputs)
+        report = result["markdown_report"]
+
+        assert "# Test Title" in report
+        assert "## Summary" in report
+        assert "## Full Report" in report
+        assert "## Politician" in report
+        assert "### Test Politician" in report
+
+
+class TestReportFormattingMetric:
+    """Test suite for report formatting evaluation metric."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.metric = ReportFormattingMetric
+
+    def test_well_formatted_report(self):
+        """Test metric scores high for well-formatted report."""
+        test_case = LLMTestCase(
+            input="Generate report for Toronto legislation",
+            actual_output="""# Toronto City Council Legislation Update
+
+## Summary
+City Council passed major climate and housing legislation in January 2024.
+
+## Full Report
+- **Bill 1-2024**: Climate Action Initiative
+- **Bill 2-2024**: Affordable Housing Strategy
+
+---
+
+## Politician Public Statements
+### Coming Soon!
+
+### Mayor Olivia Chow
+**Source:** https://example.com/statement
+
+Statement about the legislation here.""",
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score >= 0.75
+
+    def test_poorly_formatted_report(self):
+        """Test metric detects poorly formatted reports."""
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""Some random text that isn't really a report
+No headers or structure here
+Just some bullet points
+- Point 1
+- Point 2""",
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score < 0.5
+
+    def test_missing_sections(self):
+        """Test metric detects missing required sections."""
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""# Title
+
+Just some content without proper section headers.""",
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score < 0.8
+
+
+class TestSectionPresenceMetric:
+    """Test suite for required section presence validation."""
+
+    def test_all_sections_present(self):
+        """Test detection of all required sections."""
+        metric = SectionPresenceMetric(
+            required_sections=[
+                "# Title",
+                "## Summary",
+                "## Full Report",
+                "## Politician",
+            ]
+        )
+
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""# Toronto Legislation
+
+## Summary
+Summary content here.
+
+## Full Report
+Report content here.
+
+## Politician Statements
+Politician content here.""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score >= 1.0
+
+    def test_missing_sections(self):
+        """Test detection of missing sections."""
+        metric = SectionPresenceMetric(
+            required_sections=["# Title", "## Summary", "## Full Report"]
+        )
+
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""# Title
+
+## Summary
+Summary here.
+
+Missing Full Report section.""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score < 1.0
+
+    def test_custom_required_sections(self):
+        """Test custom required sections."""
+        metric = SectionPresenceMetric(
+            required_sections=[
+                "# Executive Summary",
+                "## Legislation",
+                "## Politicians",
+            ]
+        )
+
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""# Executive Summary
+Content
+
+## Legislation
+Content
+
+## Politicians
+Content""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score >= 1.0
+
+
+class TestMarkdownSyntaxMetric:
+    """Test suite for markdown syntax validation."""
+
+    def test_valid_markdown_syntax(self):
+        """Test detection of valid markdown syntax."""
+        metric = MarkdownSyntaxMetric(threshold=0.9)
+
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""# Title
+
+## Section 1
+
+- Bullet point 1
+- Bullet point 2
+
+**Bold text** and *italic text*
+
+[Link text](https://example.com)
+
+---
+
+### Subsection
+
+1. Numbered item 1
+2. Numbered item 2""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score >= 0.9
+
+    def test_broken_markdown_syntax(self):
+        """Test detection of broken markdown."""
+        metric = MarkdownSyntaxMetric(threshold=0.9)
+
+        test_case = LLMTestCase(
+            input="Generate report",
+            actual_output="""#Title (missing space)
+
+##Section (missing space)
+
+-Bullet (missing space)
+*[text(no closing bracket)""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score < 0.5
+
+
+class TestReportFormatterIntegration:
+    """Integration tests for report formatter."""
+
+    def test_full_report_generation(
+        self,
+        sample_writer_output: dict[str, Any],
+        sample_political_statements: list[dict],
+    ):
+        """Test complete report generation workflow."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title=sample_writer_output["title"],
+                summary=sample_writer_output["summary"],
+                body=sample_writer_output["body"],
+            ),
+            "politician_public_statements": sample_political_statements,
+        }
+
+        result = report_formatter(inputs)
+        report = result["markdown_report"]
+
+        assert isinstance(report, str)
+        assert len(report) > 100
+        assert report.startswith("#")
+
+    def test_report_with_multiple_politicians(
+        self, sample_writer_output: dict[str, Any]
+    ):
+        """Test report with multiple politician entries."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title="Test",
+                summary="Summary",
+                body="Body",
+            ),
+            "politician_public_statements": [
+                {
+                    "name": "Politician 1",
+                    "statement_summaries": [
+                        {"source": "https://a.com", "summary": "Statement 1"}
+                    ],
+                },
+                {
+                    "name": "Politician 2",
+                    "statement_summaries": [
+                        {"source": "https://b.com", "summary": "Statement 2"}
+                    ],
+                },
+                {
+                    "name": "Politician 3",
+                    "statement_summaries": [
+                        {"source": "https://c.com", "summary": "Statement 3"}
+                    ],
+                },
+            ],
+        }
+
+        result = report_formatter(inputs)
+        report = result["markdown_report"]
+
+        assert "### Politician 1" in report
+        assert "### Politician 2" in report
+        assert "### Politician 3" in report
+
+    def test_report_with_multiple_statements(
+        self, sample_writer_output: dict[str, Any]
+    ):
+        """Test report with multiple statements per politician."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title="Test",
+                summary="Summary",
+                body="Body",
+            ),
+            "politician_public_statements": [
+                {
+                    "name": "Test Politician",
+                    "statement_summaries": [
+                        {"source": "https://source1.com", "summary": "First statement"},
+                        {
+                            "source": "https://source2.com",
+                            "summary": "Second statement",
+                        },
+                        {"source": "https://source3.com", "summary": "Third statement"},
+                    ],
+                }
+            ],
+        }
+
+        result = report_formatter(inputs)
+        report = result["markdown_report"]
+
+        assert report.count("source1.com") == 1
+        assert report.count("source2.com") == 1
+        assert report.count("source3.com") == 1
+
+
+class TestReportFormatterEdgeCases:
+    """Edge case tests for report formatter."""
+
+    def test_empty_title(self):
+        """Test handling of empty title."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title="",
+                summary="Summary",
+                body="Body",
+            ),
+            "politician_public_statements": [],
+        }
+
+        result = report_formatter(inputs)
+        assert "markdown_report" in result
+
+    def test_very_long_content(self):
+        """Test handling of very long content."""
+        from pipelines.node.report_formatter import report_formatter
+
+        long_body = "x" * 10000
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title="Long Report",
+                summary="A very long summary " * 100,
+                body=long_body,
+            ),
+            "politician_public_statements": [],
+        }
+
+        result = report_formatter(inputs)
+        assert len(result["markdown_report"]) > 10000
+
+    def test_special_characters_in_title(self):
+        """Test handling of special characters in titles."""
+        from pipelines.node.report_formatter import report_formatter
+
+        inputs: ChainData = {
+            "legislation_summary": WriterOutput(
+                title="Test: Special Chars & More (#1)",
+                summary="Summary with émojis 🎉",
+                body="- Point with **bold** and *italic*",
+            ),
+            "politician_public_statements": [],
+        }
+
+        result = report_formatter(inputs)
+        assert "# Test:" in result["markdown_report"]
+
+
+def run_report_formatter_evaluation() -> dict[str, Any]:
+    """Run full evaluation suite for report formatter.
+
+    Returns:
+        Dictionary with evaluation results
+    """
+    from deepeval import evaluate
+
+    test_cases = [
+        LLMTestCase(
+            input="Generate markdown report for Toronto legislation",
+            actual_output="""# Toronto City Council Legislation Update - January 2024
+
+## Summary
+City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.
+
+## Full Report
+- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030, mandates building retrofits, $50M renewable energy investment
+
+- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units in large developments, establishes $100M housing trust, implements income-based rent control
+
+---
+
+## Politician Public Statements
+### Coming Soon!
+
+### Olivia Chow
+**Legislation Source Link:** https://www.toronto.ca/mayor/news/
+
+Mayor Chow emphasized the climate legislation as a historic step.
+
+### Josh Matlow
+**Legislation Source Link:** https://www.thestar.com/opinion/
+
+Councilor Matlow expressed conditional support for the climate bill.""",
+        ),
+        LLMTestCase(
+            input="Generate report",
+            actual_output="""Random text without proper structure
+No headers or formatting
+Just plain text""",
+        ),
+    ]
+
+    metrics = create_report_formatting_metric(
+        threshold=0.75,
+        strict_sections=True,
+        check_syntax=True,
+    )
+
+    results = evaluate(test_cases=test_cases, metrics=metrics)
+    return results
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/evals/test_summary_writer.py
+++ b/evals/test_summary_writer.py
@@ -1,0 +1,383 @@
+"""Unit tests for SummaryWriter component.
+
+Tests the SummaryWriter's ability to create accurate,
+complete, and well-structured summaries from legislation notes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.metrics import GEval
+from deepeval.test_case import LLMTestCase
+
+from evals.metrics.summary_quality import (
+    SummaryQualityMetric,
+    SchemaComplianceMetric,
+    create_summary_quality_metric,
+)
+from evals.metrics.no_hallucination import (
+    NoHallucinationMetric,
+    ClaimVerifiabilityMetric,
+)
+from utils.schemas import WriterOutput
+
+
+class TestSummaryWriter:
+    """Test suite for SummaryWriter component."""
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self, sample_legislation_notes: str, sample_writer_output: dict[str, Any]
+    ):
+        self.notes = sample_legislation_notes
+        self.expected_output = sample_writer_output
+
+    def test_writer_output_schema_validation(self):
+        """Test WriterOutput schema correctly validates output."""
+        valid_output = WriterOutput(
+            title="Test Title",
+            summary="Test summary",
+            body="Test body content",
+        )
+
+        assert valid_output.title == "Test Title"
+        assert valid_output.summary == "Test summary"
+        assert valid_output.body == "Test body content"
+
+    def test_writer_output_optional_fields(self):
+        """Test WriterOutput handles optional fields correctly."""
+        minimal_output = WriterOutput()
+
+        assert minimal_output.title is None
+        assert minimal_output.summary is None
+        assert minimal_output.body is None
+
+    @patch("pipelines.node.summary_writer.model.invoke")
+    def test_summary_writer_produces_valid_schema(
+        self,
+        mock_invoke: MagicMock,
+        sample_legislation_notes: str,
+    ):
+        """Test that summary writer produces valid WriterOutput."""
+        mock_invoke.return_value = WriterOutput(
+            title="Toronto Legislation Update",
+            summary="City Council passed climate and housing legislation.",
+            body="- Climate Action: 65% GHG reduction\n- Housing: 20% affordable units",
+        )
+
+        from pipelines.node.summary_writer import research_summary_writer
+        from utils.schemas import ChainData
+
+        inputs: ChainData = {"notes": sample_legislation_notes}
+        result = research_summary_writer(inputs)
+
+        assert "legislation_summary" in result
+        summary = result["legislation_summary"]
+        assert summary is not None
+        assert summary.title is not None
+        assert summary.summary is not None
+        assert summary.body is not None
+
+    @patch("pipelines.node.summary_writer.model.invoke")
+    def test_summary_writer_handles_no_content(
+        self,
+        mock_invoke: MagicMock,
+    ):
+        """Test that summary writer handles empty notes gracefully."""
+        mock_invoke.return_value = WriterOutput(
+            title="No Content",
+            summary=None,
+            body=None,
+        )
+
+        from pipelines.node.summary_writer import research_summary_writer
+        from utils.schemas import ChainData
+
+        inputs: ChainData = {"notes": ""}
+        result = research_summary_writer(inputs)
+
+        assert "legislation_summary" in result
+
+
+class TestSummaryQualityMetric:
+    """Test suite for summary quality evaluation metric."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.metric = SummaryQualityMetric
+
+    def test_high_quality_summary(self, mock_retrieval_context: str):
+        """Test metric scores high for quality summary."""
+        test_case = LLMTestCase(
+            input="Summarize the legislation for Toronto",
+            actual_output="""## Toronto City Council Legislation Update
+
+### Summary
+City Council passed two major bills: Climate Action Initiative (Bill 1) targeting 65% GHG reduction by 2030, and Affordable Housing Strategy (Bill 2) requiring 20% affordable units in new developments.
+
+### Key Points
+- **Climate Bill (Bill 1)**: Passed 38-7, $50M renewable energy investment
+- **Housing Bill (Bill 2)**: Passed 42-3, $100M housing trust established
+- Both bills align with council priorities for 2024""",
+            retrieval_context=mock_retrieval_context,
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score >= 0.75
+        assert self.metric.reason is not None
+
+    def test_incomplete_summary(self, mock_retrieval_context: str):
+        """Test metric detects incomplete summaries."""
+        test_case = LLMTestCase(
+            input="Summarize the legislation for Toronto",
+            actual_output="""Summary:
+- Climate bill passed
+- Housing mentioned
+
+(Only partial coverage, missing key details)""",
+            retrieval_context=mock_retrieval_context,
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score < 0.8
+
+    def test_biased_summary(self, mock_retrieval_context: str):
+        """Test metric detects biased or editorialized summaries."""
+        test_case = LLMTestCase(
+            input="Summarize the legislation for Toronto",
+            actual_output="""## Summary
+
+The greedy developers will love this, but the climate bill is absolutely terrible and will destroy the economy!
+
+- Climate Action: Bad for business
+- Housing: Too little, too late from out-of-touch politicians
+
+This legislation proves the council doesn't understand economics.""",
+            retrieval_context=mock_retrieval_context,
+        )
+
+        self.metric.measure(test_case)
+        assert self.metric.score < 0.5
+
+
+class TestSchemaComplianceMetric:
+    """Test suite for WriterOutput schema compliance validation."""
+
+    def test_valid_schema_compliance(self):
+        """Test that properly formatted output passes schema check."""
+        metric = SchemaComplianceMetric()
+
+        test_case = LLMTestCase(
+            input="Summarize the legislation",
+            actual_output="""# Title of Legislation
+
+## Summary
+Brief 1-2 sentence summary of the legislation.
+
+## Details
+- Point 1
+- Point 2
+- Point 3""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score >= 0.8
+
+    def test_missing_title(self):
+        """Test detection of missing title."""
+        metric = SchemaComplianceMetric()
+
+        test_case = LLMTestCase(
+            input="Summarize the legislation",
+            actual_output="""Summary of legislation content here.
+
+Details:
+- Point 1
+- Point 2""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score < 1.0
+
+    def test_missing_body(self):
+        """Test detection of missing body."""
+        metric = SchemaComplianceMetric()
+
+        test_case = LLMTestCase(
+            input="Summarize the legislation",
+            actual_output="""# Title of Legislation
+
+## Summary
+Brief summary of the legislation.""",
+        )
+
+        metric.measure(test_case)
+        assert metric.score < 1.0
+
+
+class TestSummaryWriterEdgeCases:
+    """Edge case tests for summary writer."""
+
+    @patch("pipelines.node.summary_writer.model.invoke")
+    def test_very_long_notes(self, mock_invoke: MagicMock):
+        """Test handling of very long input notes."""
+        long_notes = "Point " * 1000
+
+        mock_invoke.return_value = WriterOutput(
+            title="Long Document Summary",
+            summary="Concise summary of lengthy content.",
+            body="- " + "\n- ".join([f"Point {i}" for i in range(50)]),
+        )
+
+        from pipelines.node.summary_writer import research_summary_writer
+        from utils.schemas import ChainData
+
+        inputs: ChainData = {"notes": long_notes}
+        result = research_summary_writer(inputs)
+
+        assert result["legislation_summary"] is not None
+
+    @patch("pipelines.node.summary_writer.model.invoke")
+    def test_unicode_content(self, mock_invoke: MagicMock):
+        """Test handling of unicode characters."""
+        mock_invoke.return_value = WriterOutput(
+            title="Café and Restaurant Regulations",
+            summary="New regulations for café outdoor seating in Toronto.",
+            body="- Unicode: café, naïve, résumé\n- Special chars: © ® ™",
+        )
+
+        from pipelines.node.summary_writer import research_summary_writer
+        from utils.schemas import ChainData
+
+        inputs: ChainData = {"notes": "Café regulations: Unicode content"}
+        result = research_summary_writer(inputs)
+
+        assert result["legislation_summary"] is not None
+        assert "café" in result["legislation_summary"].title.lower()
+
+    @patch("pipelines.node.summary_writer.model.invoke")
+    def test_no_legislation_patterns(self, mock_invoke: MagicMock):
+        """Test that 'no legislation' patterns are handled."""
+        no_content_patterns = [
+            "No Content",
+            "No Recent Legislation",
+            "None",
+            "N/A",
+            "no recent legislation found",
+        ]
+
+        from pipelines.node.summary_writer import research_summary_writer
+        from utils.schemas import ChainData
+
+        for pattern in no_content_patterns:
+            mock_invoke.return_value = WriterOutput(
+                title=pattern,
+                summary="No content",
+                body="No body",
+            )
+
+            inputs: ChainData = {"notes": "Some notes"}
+            result = research_summary_writer(inputs)
+
+            assert result["legislation_summary"] is None
+
+
+class TestMultiDimensionalSummaryMetric:
+    """Test suite for multi-dimensional summary quality metric."""
+
+    def test_metric_initialization(self):
+        """Test that multi-dimensional metric initializes correctly."""
+        from evals.metrics.summary_quality import MultiDimensionalSummaryMetric
+
+        metric = MultiDimensionalSummaryMetric(
+            factual_weight=0.5,
+            completeness_weight=0.2,
+            clarity_weight=0.15,
+            objectivity_weight=0.15,
+            threshold=0.75,
+        )
+
+        assert metric.factual_weight == 0.5
+        assert metric.completeness_weight == 0.2
+        assert metric.clarity_weight == 0.15
+        assert metric.objectivity_weight == 0.15
+
+    def test_custom_weight_configuration(self):
+        """Test custom weight configuration."""
+        from evals.metrics.summary_quality import MultiDimensionalSummaryMetric
+
+        metric = MultiDimensionalSummaryMetric(
+            factual_weight=0.6,
+            completeness_weight=0.3,
+            clarity_weight=0.05,
+            objectivity_weight=0.05,
+        )
+
+        assert (
+            metric.factual_weight
+            + metric.completeness_weight
+            + metric.clarity_weight
+            + metric.objectivity_weight
+            == 1.0
+        )
+
+
+def run_summary_writer_evaluation() -> dict[str, Any]:
+    """Run full evaluation suite for summary writer.
+
+    Returns:
+        Dictionary with evaluation results
+    """
+    retrieval_context = """
+    Source: Toronto City Council Official Website
+
+    BILL 1-2024: CLIMATE ACTION INITIATIVE
+    Passed: January 15, 2024 | Vote: 38-7
+    - 65% GHG reduction by 2030
+    - $50M renewable energy investment
+    - Mandatory building retrofits
+
+    BILL 2-2024: AFFORDABLE HOUSING STRATEGY
+    Passed: January 22, 2024 | Vote: 42-3
+    - 20% affordable units required
+    - $100M housing trust
+    - Income-based rent control
+    """
+
+    test_cases = [
+        LLMTestCase(
+            input="Summarize Toronto legislation for January 2024",
+            actual_output="""# Toronto City Council Legislation Update
+
+## Summary
+City Council passed two significant bills: Climate Action Initiative (Bill 1) establishing 65% GHG reduction target and Affordable Housing Strategy (Bill 2) requiring 20% affordable units in new developments.
+
+## Full Report
+- **Climate Action Initiative (Bill 1)**: Passed 38-7, 65% GHG reduction by 2030, $50M renewable investment
+- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, 20% affordable units, $100M housing trust
+- Both bills represent major council priorities for 2024""",
+            retrieval_context=retrieval_context,
+        ),
+        LLMTestCase(
+            input="Summarize Toronto legislation",
+            actual_output="Some bills passed. Climate stuff. Housing maybe.",
+            retrieval_context=retrieval_context,
+        ),
+    ]
+
+    metrics = create_summary_quality_metric(
+        threshold=0.75,
+        multi_dimensional=True,
+        include_schema_check=True,
+    )
+
+    results = evaluate(test_cases=test_cases, metrics=metrics)
+    return results
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a DeepEval-based "LLM as a judge" evaluation suite covering all five pipeline components. Evaluations use custom metrics that score outputs against domain-specific criteria rather than just pattern-matching.

## Changes

- **`evals/conftest.py`** — shared fixtures: mock city inputs, sample legislation content, expected output shapes; API key stubs for running evals without live calls
- **`evals/metrics/`** *(new directory)*:
  - `legislation_accuracy.py` — verifies legislation finder returns real, reachable sources
  - `no_hallucination.py` — checks that summary claims are grounded in source content
  - `political_relevance.py` — scores whether politician statements are topically matched to the legislation
  - `report_formatting.py` — validates markdown structure and required section presence
  - `summary_quality.py` — scores completeness and specificity of structured summary fields
- **`evals/test_legislation_finder.py`** — end-to-end agent invocation tests with reliability gate assertions
- **`evals/test_political_commentary.py`** — political agent tests checking figure discovery and statement extraction
- **`evals/test_report_formatter.py`** — formatting correctness and edge case handling (missing summary, empty statements)
- **`evals/test_summary_writer.py`** — structured output validation against `WriterOutput` schema
- **`evals/test_e2e_pipeline.py`** — full pipeline run with assertions on final markdown report quality
- **`evals/README.md`** — documents metric design rationale, how to run evals, and how to add new metrics

## Why

Manual spot-checks of pipeline outputs don't scale across cities or model changes. LLM-as-a-judge metrics let us catch regressions in output quality (e.g., hallucinated bill numbers, missing politician names) automatically, and provide a signal for comparing the impact of prompt or model changes.