### PR TITLE
chore: move multi-city orchestration into runner layer

### DIFF
--- a/evals/test_e2e_pipeline.py
+++ b/evals/test_e2e_pipeline.py
@@ -62,13 +62,13 @@ class TestEndToEndPipeline:
 
     @patch("pipelines.nv_local.chain.invoke")
     def test_pipeline_handles_multiple_cities(self, mock_invoke: MagicMock):
-        """Test pipeline handles multiple cities."""
+        """Test runner handles multiple cities."""
         cities = ["Toronto", "New York City", "San Diego"]
         mock_invoke.side_effect = [
             {"city": city, "markdown_report": f"# {city} Report"} for city in cities
         ]
 
-        from pipelines.nv_local import run_pipelines_for_cities
+        from runners.run_container_job import run_pipelines_for_cities
 
         results = run_pipelines_for_cities(cities)
 
@@ -325,7 +325,7 @@ class TestSupportedCities:
 class TestPipelineRendering:
     """Test pipeline output rendering."""
 
-    @patch("pipelines.nv_local.run_pipelines_for_cities")
+    @patch("runners.run_container_job.run_pipelines_for_cities")
     def test_render_city_reports(
         self,
         mock_run: MagicMock,
@@ -337,14 +337,14 @@ class TestPipelineRendering:
             "NYC": {"markdown_report": "# NYC Report"},
         }
 
-        from pipelines.nv_local import render_city_reports_markdown
+        from runners.run_container_job import render_city_reports_markdown
 
         result = render_city_reports_markdown(mock_run.return_value)
 
         assert "## Toronto" in result
         assert "## NYC" in result
 
-    @patch("pipelines.nv_local.run_pipelines_for_cities")
+    @patch("runners.run_container_job.run_pipelines_for_cities")
     def test_render_with_errors(self, mock_run: MagicMock):
         """Test rendering with pipeline errors."""
         mock_run.return_value = {
@@ -354,7 +354,7 @@ class TestPipelineRendering:
             },
         }
 
-        from pipelines.nv_local import render_city_reports_markdown
+        from runners.run_container_job import render_city_reports_markdown
 
         result = render_city_reports_markdown(mock_run.return_value)
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
-"""Entrypoint shim that delegates to the NV Local pipeline runner."""
+"""Entrypoint shim that delegates to the NV Local multi-city runner."""
 
-from pipelines.nv_local import main as pipeline_main
+from runners.run_container_job import main as runner_main
 
 
 if __name__ == "__main__":
-    pipeline_main()
+    raise SystemExit(runner_main())

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -1,10 +1,8 @@
 from data import SUPPORTED_CITIES
 from pipelines.nv_local import (
     chain,
-    render_city_reports_markdown,
     run_markdown_report,
     run_pipeline,
-    run_pipelines_for_cities,
 )
 from pipelines.node.legislation_finder import (
     run_legislation_finder,
@@ -28,8 +26,6 @@ __all__ = [
     "SUPPORTED_CITIES",
     "run_pipeline",
     "run_markdown_report",
-    "run_pipelines_for_cities",
-    "render_city_reports_markdown",
     "run_legislation_finder",
     "run_content_retrieval",
     "research_note_taker",

--- a/pipelines/nv_local.py
+++ b/pipelines/nv_local.py
@@ -1,11 +1,10 @@
-"""NV Local pipeline entry points."""
+"""NV Local single-city pipeline entry points."""
 
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from pipelines.node.content_retrieval import content_retrieval_chain
 from pipelines.node.email_sender import send_email_to_subscribers
@@ -13,8 +12,8 @@ from pipelines.node.legislation_finder import legislation_finder_chain
 from pipelines.node.note_taker import note_taker_chain
 from pipelines.node.politician_commentary import politician_commentary_chain
 from pipelines.node.report_formatter import report_formatter_chain
-from data import SUPPORTED_CITIES
 from pipelines.node.summary_writer import summary_writer_chain
+from data import SUPPORTED_CITIES
 
 chain = (
     legislation_finder_chain
@@ -39,63 +38,15 @@ def run_markdown_report(city: str) -> str:
     return run_pipeline(city).get("markdown_report", "")
 
 
-def run_pipelines_for_cities(
-    cities: Sequence[str] = SUPPORTED_CITIES,
-) -> dict[str, dict[str, Any]]:
-    """Execute one pipeline per city concurrently."""
-
-    ordered_cities = tuple(cities)
-    results_by_city: dict[str, dict[str, Any]] = {}
-
-    if not ordered_cities:
-        return results_by_city
-
-    with ThreadPoolExecutor(max_workers=len(ordered_cities)) as executor:
-        futures = {executor.submit(run_pipeline, city): city for city in ordered_cities}
-
-        for future in as_completed(futures):
-            city = futures[future]
-
-            try:
-                results_by_city[city] = future.result()
-            except Exception as exc:  # noqa: BLE001
-                results_by_city[city] = {
-                    "error": f"{type(exc).__name__}: {exc}",
-                    "markdown_report": "",
-                }
-
-    return results_by_city
-
-
-def render_city_reports_markdown(
-    results_by_city: Mapping[str, dict[str, Any]],
-    cities: Sequence[str] = SUPPORTED_CITIES,
-) -> str:
-    """Render city pipeline results as a markdown document."""
-
-    sections: list[str] = []
-
-    for city in cities:
-        city_result = results_by_city.get(city, {})
-        report = city_result.get("markdown_report", "")
-        error_message = city_result.get("error")
-
-        sections.append(f"## {city}")
-
-        if error_message:
-            sections.append(f"**Error:** `{error_message}`")
-        elif report:
-            sections.append(report)
-        else:
-            sections.append("_No markdown report was generated for this city._")
-
-    return "\n\n".join(sections)
-
-
 def main() -> None:
-    """CLI entry point that runs the pipeline and emits markdown."""
+    """CLI entry point that runs the pipeline for one city."""
 
     parser = argparse.ArgumentParser(description="Run the NV Local research pipeline.")
+    parser.add_argument(
+        "city",
+        choices=SUPPORTED_CITIES,
+        help="City to run the NV Local pipeline for.",
+    )
     parser.add_argument(
         "-o",
         "--output",
@@ -110,9 +61,8 @@ def main() -> None:
     )
 
     args = parser.parse_args()
-    print(f"Running NV Local pipeline for {', '.join(SUPPORTED_CITIES)} in parallel...")
-    results_by_city = run_pipelines_for_cities(SUPPORTED_CITIES)
-    report = render_city_reports_markdown(results_by_city, SUPPORTED_CITIES)
+    print(f"Running NV Local pipeline for {args.city}...")
+    report = run_markdown_report(args.city)
 
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/runners/run_cli_main.py
+++ b/runners/run_cli_main.py
@@ -18,7 +18,7 @@ from rich.markdown import Markdown
 from rich import box
 
 from data import SUPPORTED_CITIES
-from pipelines.nv_local import (
+from runners.run_container_job import (
     render_city_reports_markdown,
     run_pipelines_for_cities,
 )

--- a/runners/run_container_job.py
+++ b/runners/run_container_job.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
 
 try:
     from dotenv import load_dotenv
@@ -12,7 +14,81 @@ except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 from data import SUPPORTED_CITIES
-from pipelines.nv_local import render_city_reports_markdown, run_pipelines_for_cities
+from pipelines.nv_local import run_pipeline
+
+
+def run_pipeline_instances(
+    pipeline_runner: Callable[[str], dict[str, Any]],
+    targets: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    """Execute one pipeline instance per target concurrently."""
+
+    ordered_targets = tuple(targets)
+    results_by_target: dict[str, dict[str, Any]] = {}
+
+    if not ordered_targets:
+        return results_by_target
+
+    with ThreadPoolExecutor(max_workers=len(ordered_targets)) as executor:
+        futures = {
+            executor.submit(pipeline_runner, target): target
+            for target in ordered_targets
+        }
+
+        for future in as_completed(futures):
+            target = futures[future]
+
+            try:
+                results_by_target[target] = future.result()
+            except Exception as exc:  # noqa: BLE001
+                results_by_target[target] = {
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "markdown_report": "",
+                }
+
+    return results_by_target
+
+
+def render_pipeline_reports_markdown(
+    results_by_target: Mapping[str, dict[str, Any]],
+    targets: Sequence[str],
+) -> str:
+    """Render multi-target pipeline results as a markdown document."""
+
+    sections: list[str] = []
+
+    for target in targets:
+        target_result = results_by_target.get(target, {})
+        report = target_result.get("markdown_report", "")
+        error_message = target_result.get("error")
+
+        sections.append(f"## {target}")
+
+        if error_message:
+            sections.append(f"**Error:** `{error_message}`")
+        elif report:
+            sections.append(report)
+        else:
+            sections.append("_No markdown report was generated for this city._")
+
+    return "\n\n".join(sections)
+
+
+def run_pipelines_for_cities(
+    cities: Sequence[str] = SUPPORTED_CITIES,
+) -> dict[str, dict[str, Any]]:
+    """Execute the NV Local pipeline concurrently for multiple cities."""
+
+    return run_pipeline_instances(run_pipeline, cities)
+
+
+def render_city_reports_markdown(
+    results_by_city: Mapping[str, dict[str, Any]],
+    cities: Sequence[str] = SUPPORTED_CITIES,
+) -> str:
+    """Render city pipeline results as a markdown document."""
+
+    return render_pipeline_reports_markdown(results_by_city, cities)
 
 
 def _parse_cities(env_value: str | None) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

Separates pipeline composition from multi-city orchestration. `pipelines/nv_local.py` now only defines the node chain; all multi-city looping, concurrency, and fault isolation moves into `runners/run_container_job.py`.

## Changes

- **`pipelines/nv_local.py`** — reduced from ~72 lines to ~11 lines; now solely responsible for composing `legislation_finder → content_retrieval → note_taker → summary_writer → politician_commentary → report_formatter` into a single chain
- **`runners/run_container_job.py`** — added `run_pipelines_for_cities()` with `ThreadPoolExecutor` for concurrent per-city execution; per-city error capture means one city failure does not block others
- **`main.py`** / **`runners/run_cli_main.py`** / **`evals/test_e2e_pipeline.py`** — import paths updated to match new location of orchestration logic

## Why

When `nv_local.py` owned both pipeline structure and multi-city orchestration, changes to concurrency strategy (thread pool size, city list source) required touching the same file as changes to pipeline node order. Splitting responsibilities means pipeline topology changes are isolated to `nv_local.py` and runner/orchestration changes are isolated to `run_container_job.py`.