### PR TITLE
feat: add LLMLingua-2 context compression infrastructure

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -1,0 +1,23 @@
+"""Pipeline-wide configuration constants."""
+
+# ---------------------------------------------------------------------------
+# Context compression (LLMLingua-2)
+# ---------------------------------------------------------------------------
+
+# Fraction of tokens to retain after compression (0.0 = nothing, 1.0 = keep all).
+# At 0.5 a 534 K-token NYC payload becomes ~267 K, safely under the 272 K limit.
+COMPRESSION_RATE: float = 0.5
+
+# Skip compression for content shorter than this — overhead not worth it.
+MIN_CHARS_TO_COMPRESS: int = 1_000
+
+# ---------------------------------------------------------------------------
+# Agent context limits
+# ---------------------------------------------------------------------------
+
+# Messages kept per agent _call_model invocation.
+# The reflection tool maintains a rolling summary so older messages are safe to drop.
+MAX_AGENT_MESSAGES: int = 30
+
+# Reflection entries kept in the agent system prompt.
+MAX_REFLECTION_ENTRIES: int = 5

--- a/config/system_prompts/__init__.py
+++ b/config/system_prompts/__init__.py
@@ -1,5 +1,6 @@
 """Agent system system_prompts."""
 
+from config.system_prompts.compression import compression_instruction
 from config.system_prompts.legislation_finder import legislation_finder_sys_prompt
 from config.system_prompts.note_taker import note_taker_sys_prompt
 from config.system_prompts.reliability_judgment import reliability_judgment_prompt
@@ -8,6 +9,7 @@ from config.system_prompts.writer import writer_sys_prompt
 from config.system_prompts.political_commentary import political_commentary_sys_prompt
 
 __all__ = [
+    "compression_instruction",
     "legislation_finder_sys_prompt",
     "note_taker_sys_prompt",
     "reliability_judgment_prompt",

--- a/config/system_prompts/compression.py
+++ b/config/system_prompts/compression.py
@@ -1,0 +1,21 @@
+compression_instruction = """
+You are compressing municipal and legislative web content for a downstream research pipeline.
+Preserve all tokens that carry factual, legal, or political significance. Specifically retain:
+
+- Bill, ordinance, resolution, and motion identifiers (numbers, codes, official titles)
+- All named entities: elected officials, agencies, committees, departments, organizations
+- Dates and timelines: introduction dates, hearing dates, vote dates, effective dates, deadlines
+- Sponsors, co-sponsors, authors, and their affiliations
+- Vote counts, outcomes, quorum details, and roll-call results
+- Key legislative provisions, policy changes, mandates, prohibitions, and exemptions
+- Budget figures, appropriations, funding sources, fiscal impact estimates
+- Affected populations, districts, neighborhoods, and communities
+- Quotes and direct statements from officials or public testimony
+- Legal citations, cross-references to existing law, and compliance requirements
+- Amendments, revisions, and differences from prior versions
+- Status indicators: passed, failed, tabled, vetoed, signed, referred to committee
+
+Discard tokens that are purely navigational, decorative, or redundant with no informational content:
+boilerplate disclaimers, cookie notices, repetitive headers and footers, generic website
+navigation text, and filler phrases that do not carry legislative meaning.
+"""

--- a/pipelines/node/content_retrieval.py
+++ b/pipelines/node/content_retrieval.py
@@ -4,6 +4,7 @@ import httpx
 from langchain_core.runnables import RunnableLambda
 
 from utils.async_runner import run_async
+from utils.context_compressor import compress_text
 from utils.mcp.tavily import extract_url_content
 from utils.schemas import ChainData
 
@@ -52,7 +53,7 @@ def run_content_retrieval(inputs: ChainData) -> ChainData:
     for url in urls:
         content = url_to_content.get(url)
         if content:
-            legislation_content.append(content)
+            legislation_content.append(compress_text(content))
         else:
             legislation_content.append(f"[Failed to fetch: {url}]")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ tweepy
 openai
 fastmcp
 tavily-python
+llmlingua

--- a/utils/context_compressor.py
+++ b/utils/context_compressor.py
@@ -1,0 +1,64 @@
+"""Context compression using LLMLingua-2 for LLM input token budget management.
+
+LLMLingua-2 uses a BERT-based token-classification model to score each token's
+informativeness and discard the least-informative ones. This preserves semantic
+quality at high compression ratios — unlike simple truncation.
+
+No API key is required. The model runs fully locally via HuggingFace transformers;
+weights are downloaded from HuggingFace Hub on first use and cached locally.
+"""
+
+import logging
+from functools import lru_cache
+
+from config.constants import COMPRESSION_RATE, MIN_CHARS_TO_COMPRESS
+from config.system_prompts import compression_instruction
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _get_compressor():
+    """Load and cache the LLMLingua-2 model (runs once per process)."""
+    from llmlingua import PromptCompressor  
+
+    logger.info("Loading LLMLingua-2 model (first call only)…")
+    compressor = PromptCompressor(
+        model_name="microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank",
+        use_llmlingua2=True,
+        device_map="cpu",
+    )
+    logger.info("LLMLingua-2 model ready.")
+    return compressor
+
+
+def compress_text(text: str, rate: float = COMPRESSION_RATE) -> str:
+    """Compress *text* using LLMLingua-2, retaining the most informative tokens.
+
+    Args:
+        text: Raw content string to compress.
+        rate: Fraction of tokens to keep (e.g. 0.5 = 50% retained).
+
+    Returns:
+        Compressed string with semantically important tokens preserved.
+    """
+    if len(text) < MIN_CHARS_TO_COMPRESS:
+        return text
+
+    compressor = _get_compressor()
+    result = compressor.compress_prompt(
+        text,
+        rate=rate,
+        instruction=compression_instruction,
+        force_tokens=["\n", ".", "!", "?", ","],
+        drop_consecutive=True,
+    )
+    compressed: str = result["compressed_prompt"]
+    logger.info(
+        "LLMLingua-2: %d → %d chars (%.0f%% retained)",
+        len(text),
+        len(compressed),
+        100 * len(compressed) / max(len(text), 1),
+    )
+    return compressed
+


### PR DESCRIPTION
## Summary

Large cities (e.g. New York City) were hitting `OpenAIContextOverflowError` because raw page content from up to 20 URLs was concatenated without any size control before being passed to the LLM — resulting in inputs exceeding the 272K-token limit (observed: 534K tokens for NYC). Beyond the hard failure, bloated contexts also degrade LLM reasoning quality and increase cost even when they do fit.

This PR introduces a semantic context compression layer using **LLMLingua-2** that compresses each fetched page's content at the point of retrieval, before it enters pipeline state. Unlike truncation, LLMLingua-2 uses a BERT-based token classifier to identify and retain the most informative tokens, preserving legislative signal (bill identifiers, dates, sponsors, provisions, votes, fiscal figures) while discarding boilerplate, navigation chrome, and redundant phrasing.

## Changes

- **`config/constants.py`** *(new)* — pipeline-wide token budget constants: `COMPRESSION_RATE` (0.5), `MIN_CHARS_TO_COMPRESS`
- **`config/system_prompts/compression.py`** *(new)* — detailed `compression_instruction` prompt guiding LLMLingua-2 on what to preserve and discard for municipal legislation content
- **`config/system_prompts/__init__.py`** — exports `compression_instruction`
- **`utils/context_compressor.py`** *(new)* — `compress_text()` wrapping LLMLingua-2; model is lazy-loaded and cached on first call, runs fully locally on CPU with no API key required
- **`pipelines/node/content_retrieval.py`** — calls `compress_text()` per URL in the assembly loop immediately after extraction
- **`requirements.txt`** — adds `llmlingua`

## Behaviour

- At `COMPRESSION_RATE=0.5`, a 534K-token NYC payload is reduced to ~267K tokens — safely under the 272K limit
- No API key or GPU required; the `microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank` model downloads once from HuggingFace Hub and runs on CPU
- Content shorter than `MIN_CHARS_TO_COMPRESS` (1000 chars) bypasses compression with no overhead
- Compression is applied per-source, meaning each URL's content is independently compressed as it is assembled — keeping the logic local to where the data enters the pipeline

## Test plan

- [ ] Run pipeline against New York City and confirm no `OpenAIContextOverflowError`
- [ ] Verify compressed content still produces accurate notes and summary output
- [ ] Confirm LLMLingua-2 model downloads and loads on first run without authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)