### PR TITLE
chore: refactor CLAUDE.MD and documentation architecture.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ pip install -r requirements.txt
 # Compile check (catches syntax errors early)
 python -m compileall -q .
 
-# Run pipeline for a single city (requires OPENAI_API_KEY + BRAVE_SEARCH_API_KEY)
+# Run pipeline for a single city (requires OPENAI_API_KEY + TAVILY_API_KEY)
 python main.py <city_name>
 
 # Run pipeline with custom output file
@@ -42,6 +42,8 @@ python main.py <city_name> -o report.md
 # Suppress stdout report
 python main.py <city_name> -q
 ```
+
+**Post-implementation verification**: After any code changes, always run `python -m compileall -q .` followed by `python main.py <city_name>` to confirm both compile-time and runtime correctness.
 
 ### Testing
 
@@ -83,20 +85,22 @@ legislation_finder → content_retrieval → note_taker → summary_writer
 - `schemas/`:
   - `state.py`: `ChainData` TypedDict (pipeline state contract)
   - `pydantic.py`: Structured output schemas (e.g., `WriterOutput`)
-- `mcp/`: MCP (Model Context Protocol) client wrappers for Brave Search, Twitter, etc.
+- `mcp/`: Per-service MCP (Model Context Protocol) client + server pairs for Tavily search/extraction, Wikidata reliability analysis, and political figure discovery. Each service lives in its own subdirectory (`tavily/`, `wikidata/`, `political_figures/`) with a `client.py` and `server.py`. Agents call `client.py` functions; `server.py` runs as a FastMCP subprocess via stdio transport. `session.py` provides `MCPSessionManager` for reusing subprocesses across tool calls within one agent invocation (avoids spawning a new process per tool call).
+- `context_compressor.py`: LLMLingua-2 wrapper (`compress_text()`) that semantically compresses raw page content before it enters pipeline state, preventing context overflow on large cities.
 - `supabase_client.py`: Loads supported cities from Supabase, manages subscriptions
 
 **Configuration** (`config/`):
 - `system_prompts/`: Prompt templates for agents and nodes
-- `search_profiles/`: Goggles profiles for Brave Search (city-specific query refinement)
+- `search_profiles/`: Tavily search profile YAML files (`legislation.yaml`, `political.yaml`) that control domain allow-lists, date windows, and query structure (city-specific query refinement)
+- `constants.py`: Pipeline-wide tuneable constants: `COMPRESSION_RATE`, `MIN_CHARS_TO_COMPRESS`, `MAX_AGENT_MESSAGES`, `MAX_REFLECTION_ENTRIES`, `AGENT_RECURSION_LIMIT`
 
 ### Data Flow Example
 
-1. **Legislation Finder**: Agent uses web search + Wikidata reliability check → outputs list of vetted URLs
-2. **Content Retrieval**: Fetches each URL's text via markdown.new → list of text blocks
+1. **Legislation Finder**: Agent uses Tavily search (via MCP) + Wikidata reliability check (via MCP) → outputs list of vetted URLs
+2. **Content Retrieval**: Fetches each URL's text via Tavily Extract (with `markdown.new` as fallback); each block is then compressed by LLMLingua-2 before being stored → list of compressed text blocks
 3. **Note Taker**: LLM summarizes all blocks into dense notes
 4. **Summary Writer**: LLM extracts structured data (title, category, impact, etc.) → `WriterOutput`
-5. **Politician Commentary**: Agent searches for elected officials and their statements on the issue
+5. **Politician Commentary**: Agent discovers officials via Political Figures MCP, searches statements via Tavily MCP, and searches Twitter via tweepy → politician public statements
 6. **Report Formatter**: Combines all outputs into markdown for display/email
 
 ### Key Design Decisions
@@ -110,12 +114,29 @@ legislation_finder → content_retrieval → note_taker → summary_writer
 - Note-taking and summary-writing are single-shot LLM transforms (simpler, cheaper)
 
 **Reliability gate before content fetching**
-- URLs are validated using Wikidata + a small-model classifier before fetching
-- Unparseable classifier output safely rejects all sources (fail-safe pattern)
+- URLs are validated using Wikidata (via MCP) + structured LLM output (`SourceReliabilityJudgment`) before fetching
+- Pydantic-enforced structured output replaced the earlier manual JSON parsing that could silently produce wrong results; now a parse failure raises rather than silently passing bad data
 
-**HTML→Markdown via external service**
-- Content retrieval delegates to `https://markdown.new/` instead of local HTML parsing
-- Trade-off: simpler code but introduces external dependency that can fail on some domains
+**Content extraction via Tavily Extract (not markdown.new)**
+- `content_retrieval.py` uses the Tavily Extract SDK as its primary extraction method; `markdown.new` remains as a fallback for domains Tavily cannot reach
+- This replaced a pattern where some sites returned 403s via `markdown.new`, producing empty content and empty reports
+
+**Semantic context compression (LLMLingua-2) per source**
+- Each fetched page is independently compressed by `utils/context_compressor.py` (BERT-based token classifier) before entering pipeline state
+- At `COMPRESSION_RATE=0.5`, a 534K-token NYC payload is reduced to ~267K tokens — avoiding `OpenAIContextOverflowError` on large cities
+- Compression is applied per-source (not once on the concatenated batch) to keep the logic local to where data enters the pipeline
+- Short content (<1000 chars) bypasses compression entirely; model is lazy-loaded on first use, no API key or GPU required
+
+**MCP server architecture for all external tools**
+- All agent tools are thin inline adapters that call FastMCP servers via stdio transport — no custom HTTP clients or manual JSON handling
+- Each service (`tavily/`, `wikidata/`, `political_figures/`) has a `server.py` that owns the business logic and a `client.py` that manages the session lifecycle
+- The earlier `tools/` directory (shared tool functions passed to agents) was eliminated; tool adapters now live directly in each agent file
+- `MCPSessionManager` (in `utils/mcp/session.py`) pre-initializes one subprocess per agent invocation and reuses it across all tool calls, preventing the process-per-call overhead that was producing process termination warnings
+
+**Rate limiting: bounded agent iterations**
+- Pipeline nodes pass `AGENT_RECURSION_LIMIT=25` (from `config/constants.py`) at `ainvoke()` time via the `config` dict, preventing unbounded tool call loops that caused 429 Too Many Requests errors in multi-city runs
+- System prompts for both agents include explicit "Exit Criteria" sections with measurable stopping conditions; `search_political_commentary` defaults to `max_results=3` (was 5)
+- Together these reduce LLM request volume ~40% while maintaining research quality
 
 **Concurrency model**
 - `runners/run_container_job.py` uses `ThreadPoolExecutor` for multi-city runs
@@ -129,24 +150,26 @@ Default config in `utils/llm/config.py`:
 - **Max tokens**: 16384
 - **Timeout**: 60s
 
-Use `get_llm()`, `get_mini_llm()` (same config), or `get_structured_llm(schema)` to instantiate. All pull from env var `OPENAI_API_KEY`.
+Use `get_llm()`, `get_mini_llm()` (same config as default), `get_structured_llm(schema)`, or `get_structured_mini_llm(schema)` to instantiate. All pull from env var `OPENAI_API_KEY`.
 
 ## External Dependencies & Environment Variables
 
 **Core** (required):
 - `OPENAI_API_KEY`: OpenAI API access
-- `BRAVE_SEARCH_API_KEY`: Brave Search via MCP
+- `TAVILY_API_KEY`: Tavily Search + Extract (web search and content retrieval via MCP)
 
 **Optional**:
-- `TWITTER_API_KEY`, `TWITTER_BEARER_TOKEN`: Twitter/X search via MCP
+- `TWITTER_BEARER_TOKEN`: Twitter/X search via tweepy SDK in Political Figures MCP server (bearer token only; v2 API does not use `TWITTER_API_KEY`)
 - `SUPABASE_URL`, `SUPABASE_KEY`: Load supported cities + email subscribers
 - `SMTP_EMAIL`, `SMTP_APP_PASSWORD`: Send reports via SMTP
 
 **External APIs** (no env needed, service-to-service):
-- Wikidata REST + SPARQL (source reliability checking)
+- Wikidata REST + SPARQL (source reliability checking via Wikidata MCP server)
 - OpenStreetMap Nominatim (country detection)
-- OpenNorth Represent (Canada) + WeVote API (USA) for political figures
-- markdown.new (content extraction)
+- OpenNorth Represent (Canada) + WeVote API (USA) for political figures (via Political Figures MCP server)
+
+**Local models** (downloaded on first run, no API key):
+- `microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank` (HuggingFace Hub) — used by `utils/context_compressor.py` for content compression; cached after first download, runs on CPU
 
 ## Common Patterns
 
@@ -160,8 +183,9 @@ Use `get_llm()`, `get_mini_llm()` (same config), or `get_structured_llm(schema)`
 
 **Agents**
 - Inherit from `BaseReActAgent` (see `agents/base_agent_template.py`)
-- Define tools as functions, then pass to agent constructor
-- Agent builds a LangGraph StateGraph with `call_model` and `tool_node` nodes
+- Tools are defined as inline adapter functions directly inside each agent file (not in a separate `tools/` directory — that was deleted in PR #36)
+- Each tool adapter calls the appropriate MCP client function and returns a LangGraph `Command` for state updates
+- Agent builds a LangGraph StateGraph with `call_model` and `tool_node` nodes; `recursion_limit` is applied at invoke-time via the config dict (not at compile-time)
 
 **Error Handling**
 - Classifier output parse failures → reject all sources (safe fallback)
@@ -182,7 +206,7 @@ Use `get_llm()`, `get_mini_llm()` (same config), or `get_structured_llm(schema)`
 **Docker**:
 ```bash
 docker build -f docker/Dockerfile -t nv-local .
-docker run -e OPENAI_API_KEY=... -e BRAVE_SEARCH_API_KEY=... nv-local
+docker run -e OPENAI_API_KEY=... -e TAVILY_API_KEY=... nv-local
 ```
 
 **Azure (CI/CD)**:
@@ -196,7 +220,8 @@ docker run -e OPENAI_API_KEY=... -e BRAVE_SEARCH_API_KEY=... nv-local
 ## Important Known Issues / WIP
 
 - Political commentary schema still evolving; if agent returns non-empty data in unexpected shape, report formatting may fail
-- Some domains fail with markdown.new extraction (rare but documented)
+- LLMLingua-2 downloads `microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank` from HuggingFace on first run (~400MB); cold starts in containerized environments will be slow until the model is cached
+- Tavily Extract can fail on some domains (access restrictions, JS-heavy SPAs); `markdown.new` fallback handles most of these but is not 100% reliable
 - No persistent report storage by default (pipeline is stateless)
 
 ## Common Development Tasks
@@ -209,9 +234,9 @@ docker run -e OPENAI_API_KEY=... -e BRAVE_SEARCH_API_KEY=... nv-local
 5. Document in `docs/ARCHITECTURE.md`
 
 **Adding an agent tool**:
-1. Define tool function in `tools/<agent_name>.py` with LangChain `@tool` decorator
-2. Pass to agent constructor
-3. Agent automatically builds `ToolNode` via `ToolNode(tools=[...])` in graph
+1. Define the tool adapter as an inline function directly in the agent file (e.g., `agents/legislation_finder.py`) with LangChain `@tool` decorator — the `tools/` directory no longer exists
+2. If the tool needs an external service, add the logic to the appropriate MCP server (`utils/mcp/<service>/server.py`) and call it from a client function (`utils/mcp/<service>/client.py`)
+3. Pass the tool adapter to the agent constructor; it is automatically included in `ToolNode`
 
 **Changing LLM model or config**:
 1. Update `utils/llm/config.py:DEFAULT_LLM_CONFIG`
@@ -220,5 +245,5 @@ docker run -e OPENAI_API_KEY=... -e BRAVE_SEARCH_API_KEY=... nv-local
 **Debugging a city pipeline failure**:
 1. Run single city: `python main.py <city_name>` (no -q flag to see output)
 2. Check error message in stdout/stderr
-3. Likely causes: missing env vars, URL fetch failure (markdown.new), classifier parsing error, external API timeout
+3. Likely causes: missing env vars (`OPENAI_API_KEY`, `TAVILY_API_KEY`), Tavily Extract failure on a domain, MCP subprocess initialization error (check that project root is on `sys.path`), agent hitting `recursion_limit=25` before completing, LLMLingua-2 model download failing on cold start
 4. Look at per-city result dict in `runners/run_container_job.py:main()` for error field

--- a/agents/base_agent_template.py
+++ b/agents/base_agent_template.py
@@ -120,13 +120,11 @@ class BaseReActAgent:
         temperature: float = 0.0,
         max_tokens: int = 2000,
         timeout: int = 30,
-        recursion_limit: int = 25,
     ):
         self.state_schema = state_schema
         # Always include reflection_tool by default
         self.tools = [reflection_tool] + tools
         self.system_prompt = system_prompt
-        self.recursion_limit = recursion_limit
 
         self.model = get_llm(
             model=model_name,
@@ -192,4 +190,4 @@ class BaseReActAgent:
         )
         graph.add_edge("tool_node", "call_model")
 
-        return graph.compile(recursion_limit=self.recursion_limit)
+        return graph.compile()

--- a/config/constants.py
+++ b/config/constants.py
@@ -21,3 +21,11 @@ MAX_AGENT_MESSAGES: int = 30
 
 # Reflection entries kept in the agent system prompt.
 MAX_REFLECTION_ENTRIES: int = 5
+
+# ---------------------------------------------------------------------------
+# Agent recursion limit
+# ---------------------------------------------------------------------------
+
+# Maximum graph steps before LangGraph raises a recursion error.
+# Prevents unbounded tool-call loops in multi-city runs.
+AGENT_RECURSION_LIMIT: int = 25

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,8 +11,7 @@ Code layout (high level):
 - `pipelines/nv_local.py`: composes the end-to-end chain and runs it for multiple cities concurrently
 - `pipelines/node/*`: individual pipeline nodes (small, single-purpose transforms)
 - `agents/*`: LangGraph ReAct agents built from `agents/base_agent_template.py`
-- `tools/*`: tool functions used by agents (web search, reliability checks, political figure discovery)
-- `utils/*`: shared helpers (LLM factory, MCP clients, schemas, Wikidata client)
+- `utils/*`: shared helpers (LLM factory, MCP clients/servers, context compressor, schemas)
 
 ## Data Flow
 
@@ -21,15 +20,18 @@ Code layout (high level):
 1) `pipelines/node/legislation_finder.py`
 
 - Calls the ReAct agent in `agents/legislation_finder.py`
-- Agent tools:
-  - `tools/legislation_finder.py:web_search` (Brave Search via MCP + Goggles)
-  - `tools/legislation_finder.py:reliability_analysis` (Wikidata lookup + LLM classifier)
+- Agent tool adapters (defined inline in the agent file — the `tools/` directory was deleted in favour of inline adapters that call MCP servers):
+  - `web_search`: calls `utils/mcp/tavily/client.py:search_legislation` (Tavily MCP server + `config/search_profiles/legislation.yaml`)
+  - `reliability_analysis`: calls `utils/mcp/wikidata/client.py:analyze_reliability` (Wikidata MCP server + structured LLM output via `SourceReliabilityJudgment` Pydantic model)
+- Agent is compiled with `recursion_limit=25` to prevent unbounded tool-call loops (added after 429 rate-limit errors in multi-city runs)
 - Output: `legislation_sources` (a list of URLs that passed reliability filtering)
 
 2) `pipelines/node/content_retrieval.py`
 
-- Fetches each URL via `https://markdown.new/<url>` and stores the returned text
-- Output: `legislation_content` (list of extracted page text blocks)
+- Fetches each URL via Tavily Extract SDK (primary); falls back to `https://markdown.new/<url>` for domains Tavily cannot reach
+- Each page's text is immediately compressed by `utils/context_compressor.py` (LLMLingua-2, `COMPRESSION_RATE=0.5`) before being appended to the list — this prevents `OpenAIContextOverflowError` on large cities (observed: 534K tokens for NYC > 272K limit)
+- Tavily Extract is capped at 20 URLs per request (API hard limit); the pipeline respects this at both the client and node layers
+- Output: `legislation_content` (list of compressed text blocks)
 
 3) `pipelines/node/note_taker.py`
 
@@ -44,10 +46,12 @@ Code layout (high level):
 5) `pipelines/node/politician_commentary.py`
 
 - Calls the ReAct agent in `agents/political_commentary_finder.py`
-- Agent tools:
-  - `tools/political_commentary_finder.py:political_figure_finder` (OpenStreetMap Nominatim + OpenNorth Represent API for CA, WeVote API for US)
-  - `tools/political_commentary_finder.py:search_political_commentary` (Brave Search + per-page LLM extraction)
-  - `tools/political_commentary_finder.py:search_political_social_media` (Twitter MCP)
+- Agent tool adapters (inline in the agent file):
+  - `political_figure_finder`: calls `utils/mcp/political_figures/client.py:find_political_figures` (OpenStreetMap Nominatim + OpenNorth Represent API for CA, WeVote API for US)
+  - `search_political_commentary`: calls Tavily MCP for search + Political Figures MCP for per-page LLM extraction; defaults to `max_results=3` (reduced from 5 to limit API volume)
+  - `search_political_social_media`: calls Political Figures MCP server, which uses tweepy SDK with `TWITTER_BEARER_TOKEN` (v2 API; no `TWITTER_API_KEY` needed)
+- Agent also compiled with `recursion_limit=25`
+- `MCPSessionManager` (`utils/mcp/session.py`) pre-initializes one Tavily MCP subprocess per agent invocation and reuses it across all tool calls within that invocation (eliminates process-per-call overhead)
 - Output: `politician_public_statements`
 
 6) `pipelines/node/report_formatter.py`
@@ -62,25 +66,33 @@ Code layout (high level):
 
 ## Runtime Model
 
-- Concurrency: `pipelines/nv_local.py:run_pipelines_for_cities` uses a `ThreadPoolExecutor` to run one city pipeline per thread.
+- Concurrency: `runners/run_container_job.py` uses a `ThreadPoolExecutor` to run one city pipeline per thread (one thread per city; no shared state between cities).
 - State passing: pipeline nodes pass a simple `TypedDict` (`utils/schemas/state.py:ChainData`) from node to node.
+- Async: MCP server communication uses async Python (`asyncio`); `utils/async_runner.py` provides a helper to call async functions from synchronous pipeline nodes.
 
 ## Key Design Decisions
 
-- Fixed chain over dynamic routing: the pipeline is a stable sequence, so each run is easy to reason about and operate.
-- ReAct agents only where tool-use is needed: legislation discovery and political commentary use tools (web search, external APIs). Note-taking and summary writing are single LLM transforms.
-- Reliability gate before fetching: legislation URLs are filtered using Wikidata context and a small-model classifier; if the classifier output cannot be parsed, the safe fallback is to reject all sources.
-- HTML extraction via `markdown.new`: content retrieval delegates page-to-text conversion to an external service, keeping the local code simple but introducing a dependency that can fail on some domains.
+- **Fixed chain over dynamic routing**: the pipeline is a stable sequence, so each run is easy to reason about and operate.
+- **ReAct agents only where tool-use is needed**: legislation discovery and political commentary use tools (web search, external APIs). Note-taking and summary writing are single LLM transforms.
+- **Reliability gate before fetching**: legislation URLs are filtered via Wikidata MCP + structured LLM output (`SourceReliabilityJudgment` Pydantic model). Structured output replaced manual JSON parsing to eliminate silent parse failures; unknown sources on recognized domains default to `conditionally_reliable` rather than being rejected outright (loosened in PR #36 to improve recall on news orgs covering city legislation).
+- **Content extraction via Tavily Extract (not `markdown.new`)**: Tavily Extract is the primary extraction method; `markdown.new` is a fallback. The switch resolved a 403 cascade pattern where some city sites blocked `markdown.new`, producing empty content and empty reports.
+- **Semantic context compression per source**: `utils/context_compressor.py` wraps LLMLingua-2 and compresses each fetched page individually before it enters pipeline state. This prevents `OpenAIContextOverflowError` on large cities (NYC reached 534K tokens, above the 272K model limit). Compression is per-source rather than post-concatenation so that each URL's content is bounded independently.
+- **MCP server architecture for external tools**: all agent tools are thin inline adapters calling FastMCP servers over stdio. Business logic lives in the server; agents are decoupled from API specifics. This replaced the `tools/` directory, which contained agent-specific functions that mixed tool registration with API client logic.
+- **Bounded agent iteration**: `recursion_limit=25` on all agent graphs + explicit "Exit Criteria" in system prompts prevent unbounded tool-call loops that caused 429 rate-limit errors in multi-city runs.
 
 ## External Dependencies
 
-- OpenAI (via `langchain-openai`): LLM calls
-- Brave Search (via Smithery-hosted MCP): web search
-- Wikidata REST + SPARQL: organization metadata used for source classification
+- OpenAI (via `langchain-openai`): LLM calls for all pipeline nodes
+- Tavily Search + Extract (via MCP server `utils/mcp/tavily/`): web search and content extraction; replaces Brave Search and the `markdown.new` dependency
+- Wikidata REST + SPARQL (via MCP server `utils/mcp/wikidata/`): organization metadata for source reliability classification
 - OpenStreetMap Nominatim: country detection for a city name
-- OpenNorth Represent API (Canada) and WeVote API (USA): political figure discovery
+- OpenNorth Represent API (Canada) and WeVote API (USA): political figure discovery (via `utils/mcp/political_figures/`)
+- Twitter/X via tweepy SDK (`TWITTER_BEARER_TOKEN`): politician tweet search inside Political Figures MCP server
+- LLMLingua-2 (`microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank`): local BERT-based token classifier for content compression; downloaded from HuggingFace Hub on first run
 - Optional: Supabase and SMTP for email delivery
 
 ## Known Gaps / WIP
 
 - The political commentary portion is still evolving; the report formatter expects a particular schema for public statements. If the political commentary agent returns non-empty data in a different shape, formatting may fail.
+- LLMLingua-2 downloads ~400MB on first run; cold starts in containerized environments are slow until the model is cached in the image or a volume.
+- Tavily Extract can fail on JS-heavy SPAs or access-restricted domains; `markdown.new` fallback handles most cases but is not 100% reliable.

--- a/pipelines/node/legislation_finder.py
+++ b/pipelines/node/legislation_finder.py
@@ -2,6 +2,7 @@ from contextlib import AsyncExitStack
 
 from langchain_core.runnables import RunnableLambda
 
+from config.constants import AGENT_RECURSION_LIMIT
 from utils.schemas import ChainData
 from utils.async_runner import run_async
 from utils.mcp.tavily.client import managed_tavily_session
@@ -13,7 +14,10 @@ async def _invoke_legislation_finder(city: str) -> dict:
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(managed_tavily_session())
         await stack.enter_async_context(managed_wikidata_session())
-        return await legislation_finder_agent.ainvoke({"city": city})
+        return await legislation_finder_agent.ainvoke(
+            {"city": city},
+            config={"recursion_limit": AGENT_RECURSION_LIMIT},
+        )
 
 
 def run_legislation_finder(inputs: ChainData) -> ChainData:

--- a/pipelines/node/politician_commentary.py
+++ b/pipelines/node/politician_commentary.py
@@ -2,6 +2,7 @@ from contextlib import AsyncExitStack
 
 from langchain_core.runnables import RunnableLambda
 
+from config.constants import AGENT_RECURSION_LIMIT
 from utils.schemas import ChainData
 from utils.async_runner import run_async
 from utils.mcp.tavily.client import managed_tavily_session
@@ -13,7 +14,10 @@ async def _invoke_political_commentary(city: str) -> dict:
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(managed_tavily_session())
         await stack.enter_async_context(managed_political_figures_session())
-        return await political_commentary_agent.ainvoke({"city": city})
+        return await political_commentary_agent.ainvoke(
+            {"city": city},
+            config={"recursion_limit": AGENT_RECURSION_LIMIT},
+        )
 
 
 def run_politician_commentary_finder(inputs: ChainData) -> ChainData:


### PR DESCRIPTION
## Summary

Synchronizes `CLAUDE.md` and `docs/ARCHITECTURE.md` with three merged PRs (#36, #37, #38) that significantly changed the codebase architecture but were not reflected in the documentation. Also refactors `AGENT_RECURSION_LIMIT` from a compile-time `graph.compile()` parameter to a named constant in `config/constants.py` passed at `ainvoke()` time.

## Changes

### Documentation updates (`CLAUDE.md` + `docs/ARCHITECTURE.md`)
- Replace all references to `BRAVE_SEARCH_API_KEY` with `TAVILY_API_KEY` (search provider migrated in PR #36)
- Remove `markdown.new` references; document Tavily Extract as primary content extraction method with `markdown.new` as fallback
- Rewrite `mcp/` section to reflect per-service directory structure (`tavily/`, `wikidata/`, `political_figures/`) with `client.py` + `server.py` pairs
- Add `MCPSessionManager` documentation (session reuse across tool calls within one agent invocation)
- Add `context_compressor.py` (LLMLingua-2) and `config/constants.py` to component listings
- Document that `tools/` directory was deleted; tool adapters now live inline in each agent file
- Update data flow: content retrieval now uses Tavily Extract + per-source LLMLingua-2 compression
- Document `recursion_limit` as passed at invocation time via `ainvoke(config=...)`, not at compile time
- Update Docker example command (`BRAVE_SEARCH_API_KEY` → `TAVILY_API_KEY`)
- Replace stale debugging failure causes with current ones (Tavily failures, MCP subprocess errors, cold-start model download)
- Update `docs/ARCHITECTURE.md` data flow entries to reflect Tavily MCP, Wikidata MCP, Political Figures MCP; add LLMLingua-2 compression rationale

### Code refactor
- **`config/constants.py`** — add `AGENT_RECURSION_LIMIT = 25` alongside existing pipeline constants
- **`agents/base_agent_template.py`** — remove `recursion_limit` parameter from `__init__` and `graph.compile()`; limit is now controlled at call-site
- **`pipelines/node/legislation_finder.py`** / **`pipelines/node/politician_commentary.py`** — pass `config={"recursion_limit": AGENT_RECURSION_LIMIT}` to `ainvoke()`; this is the correct LangGraph pattern for per-invocation overrides

## Why

The compile-time `recursion_limit` in `graph.compile()` sets a graph-wide default that cannot be overridden at call time. Passing it via `ainvoke(config=...)` is the standard LangGraph pattern and allows callers to override the limit if needed without recompiling the graph.