### PR TITLE
chore: use single city pipeline when running CLI tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ pip install -r requirements.txt
 
 - Copy `.env.example` to `.env` and set required keys
 - **Critical**: `main.py` does NOT auto-load `.env`; it expects env vars to be present in the shell
-- The main entrypoint is `main.py` → `runners/run_container_job.py` → `pipelines/nv_local.py`
+- **CLI entrypoint**: `main.py` → `pipelines/nv_local.py` (single-city, requires city argument validated against Supabase `supported_cities`)
+- **Docker/Azure entrypoint**: `runners/run_container_job.py` (multi-city concurrent ingestion, must not be modified for CLI changes)
 
 ### Common Commands
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
-"""Entrypoint shim that delegates to the NV Local multi-city runner."""
+"""CLI entrypoint for single-city NV Local pipeline runs."""
 
-from runners.run_container_job import main as runner_main
+import logging
+
+from pipelines.nv_local import main as pipeline_main
 
 
 if __name__ == "__main__":
-    raise SystemExit(runner_main())
+    logging.basicConfig(level=logging.INFO)
+    pipeline_main()


### PR DESCRIPTION
## Summary

- **Rewired `main.py`** from the multi-city container runner (`runners/run_container_job.py`) to the single-city pipeline entrypoint (`pipelines/nv_local.py`)
- The CLI now **requires a city argument** validated against the Supabase `supported_cities` table via argparse `choices` — unsupported or missing cities are rejected before the pipeline starts
- **Docker/Azure entrypoint is untouched** — `runners/run_container_job.py` continues to run concurrent multi-city ingestion for scheduled container jobs
- Updated `CLAUDE.md` to document the separation between CLI and Docker/Azure entrypoints

## Motivation

Previously, running `python main.py` would fetch all supported cities from Supabase and execute the pipeline for every city concurrently. This made sense for scheduled container runs but not for local CLI usage, where you typically want to test or run a single city. The single-city CLI with Supabase validation already existed in `pipelines/nv_local.py:main()` — this PR simply wires `main.py` to it.

## Test plan

- [x] `python main.py` (no args) → shows usage with valid city choices from Supabase
- [x] `python main.py FakeCity` → rejects with "invalid choice" error
- [x] `python main.py Toronto -q` → runs single-city pipeline successfully
- [x] Docker entrypoint (`CMD ["python", "runners/run_container_job.py"]`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)