### PR TITLE
chore: add Claude Code slash commands for commits and PRs

### DIFF
--- a/.claude/commands/commit-maker.md
+++ b/.claude/commands/commit-maker.md
@@ -1,0 +1,18 @@
+---
+description: Create commits and push changes to the repository
+---
+
+# Commit Message Convention
+
+Use one of these prefixes in the commit message:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `chore:` — maintenance task
+- `docs:` — documentation-only change
+
+# Rules
+
+- Write clear, concise commit messages describing the change.
+- Keep each commit focused on a single logical change.
+- Never push to the remote without human approval.

--- a/.claude/commands/pr-maker.md
+++ b/.claude/commands/pr-maker.md
@@ -14,3 +14,5 @@ Use one of these prefixes in the PR title:
 # Rules
 
 - Never merge the PR without human approval.
+- Do not add Generated with Claude Code within the body of PR
+- Do not add a Test Plan section

--- a/.claude/commands/pr-maker.md
+++ b/.claude/commands/pr-maker.md
@@ -1,0 +1,16 @@
+---
+description: Create a PR to the Next-Voters parent repository
+---
+
+# PR Title Convention
+
+Use one of these prefixes in the PR title:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `chore:` — maintenance task
+- `docs:` — documentation-only change
+
+# Rules
+
+- Never merge the PR without human approval.


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/commit-maker.md` — reusable slash command that enforces conventional commit message prefixes (`feat:`, `fix:`, `chore:`, `docs:`) and requires human approval before pushing
- Adds `.claude/commands/pr-maker.md` — reusable slash command that enforces conventional PR title prefixes and requires human approval before merging
- These commands standardize how Claude Code interacts with the repository's git workflow