### PR TITLE
chore: add Claude Code commands and Supabase MCP config

### DIFF
--- a/.claude/commands/pr-maker.md
+++ b/.claude/commands/pr-maker.md
@@ -1,6 +1,8 @@
 ---
 description: Create a PR to the Next-Voters parent repository
 ---
+# Base Branch
+Do NOT use the base branch of main, unless explicitly stated by the developer. Base branch, by default, shall be staging. 
 
 # PR Title Convention
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add reusable Claude Code slash commands (`commit-maker`, `pr-maker`) for standardized commit messages and PR creation workflows
- Add `.mcp.json` with Supabase MCP server configuration for improved developer experience when interacting with the database