### PR TITLE
fix: resolve political commentary agent data loss and robustness bugs

### DIFF
--- a/agents/political_commentary_finder.py
+++ b/agents/political_commentary_finder.py
@@ -123,7 +123,7 @@ async def search_political_commentary(
         politician: The name of the politician to search commentary for.
         city: The city context for local political content (from state).
         tool_call_id: Injected by LangGraph — used to associate the ToolMessage.
-        max_results: Maximum number of results to return (default 5).
+        max_results: Maximum number of results to return (default 3).
 
     Returns:
         A Command object that updates the state with political commentary
@@ -154,14 +154,19 @@ async def search_political_commentary(
         political_commentary = []
         for r in results:
             url = r.get("url", "")
+            if not url:
+                continue
             extraction = await mcp_extract_commentary(
                 url=url, politician=politician, query=query
             )
+            comment = extraction.get("commentary", "")
+            if not comment or comment.startswith(("Failed to", "No commentary found")):
+                continue
             political_commentary.append(
                 {
                     "politician": politician,
                     "source_url": url,
-                    "comment": extraction.get("commentary", ""),
+                    "comment": comment,
                 }
             )
 
@@ -312,10 +317,11 @@ async def search_political_social_media(
 
         summary_lines = [f"Found {len(social_posts)} tweet(s) from {politician}:"]
         for post in social_posts:
+            text = post["text"] or ""
             text_preview = (
-                post["text"][:PREVIEW_MAX_LENGTH] + "..."
-                if len(post["text"]) > PREVIEW_MAX_LENGTH
-                else post["text"]
+                text[:PREVIEW_MAX_LENGTH] + "..."
+                if len(text) > PREVIEW_MAX_LENGTH
+                else text
             )
             summary_lines.append(f"  - {text_preview}")
 

--- a/pipelines/node/politician_commentary.py
+++ b/pipelines/node/politician_commentary.py
@@ -1,5 +1,6 @@
 from contextlib import AsyncExitStack
 
+from langchain_core.messages import HumanMessage
 from langchain_core.runnables import RunnableLambda
 
 from config.constants import AGENT_RECURSION_LIMIT
@@ -9,22 +10,45 @@ from utils.mcp.tavily.client import managed_tavily_session
 from utils.mcp.political_figures.client import managed_political_figures_session
 
 
-async def _invoke_political_commentary(city: str) -> dict:
+async def _invoke_political_commentary(
+    city: str, topic: str, research_notes: str
+) -> dict:
+    """Invoke the political commentary agent with full pipeline context."""
     from agents.political_commentary_finder import political_commentary_agent
+
+    task_message = f"Research political commentary for {city}"
+    if topic:
+        task_message += f" on the topic of: {topic}"
+
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(managed_tavily_session())
         await stack.enter_async_context(managed_political_figures_session())
         return await political_commentary_agent.ainvoke(
-            {"city": city},
+            {
+                "city": city,
+                "topic": topic,
+                "research_notes": research_notes,
+                "messages": [HumanMessage(content=task_message)],
+            },
             config={"recursion_limit": AGENT_RECURSION_LIMIT},
         )
 
 
 def run_politician_commentary_finder(inputs: ChainData) -> ChainData:
+    """Run the political commentary agent and merge results into pipeline state."""
     city = inputs.get("city", "Unknown")
-    agent_result = run_async(lambda: _invoke_political_commentary(city))
+    topic = inputs.get("topic", "")
+    research_notes = inputs.get("notes", "")
+    agent_result = run_async(
+        lambda: _invoke_political_commentary(city, topic, research_notes)
+    )
     political_commentary = agent_result.get("political_commentary", [])
-    return {**inputs, "politician_public_statements": political_commentary}
+    social_media_posts = agent_result.get("social_media_posts", [])
+    return {
+        **inputs,
+        "politician_public_statements": political_commentary,
+        "social_media_posts": social_media_posts,
+    }
 
 
 politician_commentary_chain = RunnableLambda(run_politician_commentary_finder)

--- a/utils/mcp/political_figures/server.py
+++ b/utils/mcp/political_figures/server.py
@@ -7,6 +7,7 @@ commentary from web pages, and searching politician tweets via tweepy.
 Usage: python -m utils.mcp.political_figures.server
 """
 
+import datetime
 import logging
 import os
 import re
@@ -131,7 +132,7 @@ def _fetch_canadian_political_figures(city: str) -> list[dict[str, Any]]:
 def _fetch_american_political_figures(city: str) -> list[dict[str, Any]]:
     """Fetch American political figures using the We Vote API."""
     we_vote_base_url = "https://api.wevoteusa.org/apis/v1/candidatesQuery"
-    current_year = "2026"
+    current_year = str(datetime.date.today().year)
     params = {"electionDay": current_year, "searchText": city}
     response = requests.get(we_vote_base_url, params=params, timeout=30)
     response.raise_for_status()
@@ -190,28 +191,6 @@ def find_political_figures(city: str) -> dict:
         return {"figures": figures, "country": country}
     except Exception as e:
         return {"error": f"Failed to find political figures: {e}", "figures": [], "country": country}
-
-
-@mcp.tool
-def fetch_page_content(url: str) -> dict:
-    """Fetch the raw text content from a URL.
-
-    Args:
-        url: The URL to fetch content from.
-
-    Returns:
-        Dict with "content" key containing the page text (truncated to 15000 chars).
-    """
-    try:
-        headers = {
-            "User-Agent": "PoliticalCommentaryAgent/1.0",
-            "Accept": "text/html,application/xhtml+xml",
-        }
-        response = httpx.get(url, headers=headers, timeout=15, follow_redirects=True)
-        response.raise_for_status()
-        return {"content": response.text[:15000]}
-    except Exception as e:
-        return {"content": f"Failed to fetch content: {e}"}
 
 
 @mcp.tool

--- a/utils/schemas/state.py
+++ b/utils/schemas/state.py
@@ -43,6 +43,7 @@ class ChainData(TypedDict):
     notes: NotRequired[str]
     legislation_summary: NotRequired[WriterOutput]
     politician_public_statements: NotRequired[list[dict[str, object]]]
+    social_media_posts: NotRequired[list[dict[str, object]]]
     markdown_report: NotRequired[str]
 
 
@@ -79,6 +80,7 @@ class PoliticalCommentaryState(BaseAgentState):
     """Agent-specific state for the political commentary agent."""
 
     city: NotRequired[str]
+    topic: NotRequired[str]
     country: NotRequired[str]
     political_figures: NotRequired[Annotated[list[PoliticalFigure], operator.add]]
     political_commentary: NotRequired[


### PR DESCRIPTION
## Summary
- **Data loss fix**: Social media posts collected by the agent are now forwarded through the pipeline via `social_media_posts` in `ChainData`, instead of being silently dropped
- **Topic & context scoping**: Pipeline node now passes `topic` and `research_notes` (from upstream note-taker) into the agent, enabling focused research and activating the Twitter context-based fallback search that was previously dead code
- **Robustness**: Filter out empty/failed commentary extractions, guard against `None` tweet text causing `TypeError`, use dynamic year for We Vote API instead of hardcoded `"2026"`, remove unused `fetch_page_content` MCP tool, fix docstring mismatch on `max_results` default