### PR TITLE
feat: graceful exit, supervisor/sub-agent, reflection & adaptive caps

### DIFF
--- a/agents/base_agent_template.py
+++ b/agents/base_agent_template.py
@@ -18,6 +18,7 @@ from typing import Callable, Union, TypeVar, Type
 from langgraph.graph import StateGraph, START, END
 from langgraph.prebuilt import ToolNode
 
+from config.constants import MAX_REFLECTION_ENTRIES
 from utils.schemas import ReflectionEntry, BaseAgentState
 from utils.tools import reflection_tool
 from utils.llm import get_llm
@@ -70,6 +71,8 @@ class BaseReActAgent:
     def _build_prompt(self, state: StateType) -> str:
         """Shared reflection context + agent prompt (static or dynamic)."""
         reflection_list: list[ReflectionEntry] = state.get("reflection_list", [])
+        if len(reflection_list) > MAX_REFLECTION_ENTRIES:
+            reflection_list = reflection_list[-MAX_REFLECTION_ENTRIES:]
 
         reflection_section = ""
         if reflection_list:

--- a/agents/legislation_finder.py
+++ b/agents/legislation_finder.py
@@ -33,10 +33,14 @@ from mcp.client.streamable_http import streamablehttp_client
 
 from agents.base_agent_template import BaseReActAgent
 from config.constants import AGENT_RECURSION_LIMIT
-from config.system_prompts import legislation_finder_sys_prompt
+from config.system_prompts import (
+    legislation_finder_subagent_sys_prompt,
+    legislation_finder_sys_prompt,
+)
 from utils.concurrency import run_parallel
 from utils.llm import get_structured_mini_llm
 from utils.schemas import LegislationFinderState, SourceAssessment
+from utils.sources import extract_url_and_snippet
 from utils.tools import web_search
 
 logger = logging.getLogger(__name__)
@@ -99,43 +103,13 @@ async def _run_discovery_agent(graph, invoke_kwargs: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-_SUBAGENT_SYSTEM = """
-You are a per-source legislation validator. For the URL below, classify it
-and decide whether it meets the research quality bar.
-
-Accept criteria (any one is sufficient):
-  - Official government / municipal website (.gov, city portal, municode,
-    legistar, council agenda portal)
-  - Factual local-news reporting on specific legislation (no opinion language)
-  - Established wire service (AP, Reuters) with concrete legislative detail
-
-Reject:
-  - Opinion pieces, editorials, blog posts
-  - Aggregators that merely *mention* legislation without specifics
-  - Paywalled content you cannot verify
-  - Irrelevant domains (marketing, social media landing pages)
-
-Produce a single structured assessment. Do not browse; reason only from the
-URL + title/snippet context provided.
-""".strip()
-
-
-def _extract_snippet(item: str | dict[str, Any]) -> tuple[str, str]:
-    """Return (url, snippet) for a discovery item — string or pre-fetched dict."""
-    if isinstance(item, dict):
-        url = str(item.get("url", "")).strip()
-        snippet = (item.get("content") or "")[:800]
-        return url, snippet
-    return str(item).strip(), ""
-
-
 def _run_per_source_subagent(city: str, item: str | dict[str, Any]) -> SourceAssessment:
     """Invoke the structured mini-LLM on one candidate URL.
 
     Returns a :class:`SourceAssessment`. On LLM failure, falls back to a
     reject decision rather than raising so the supervisor batch keeps going.
     """
-    url, snippet = _extract_snippet(item)
+    url, snippet = extract_url_and_snippet(item)
     if not url:
         return SourceAssessment(url="", accepted=False, rationale="empty url")
 
@@ -147,7 +121,7 @@ def _run_per_source_subagent(city: str, item: str | dict[str, Any]) -> SourceAss
     try:
         result = llm.invoke(
             [
-                {"role": "system", "content": _SUBAGENT_SYSTEM},
+                {"role": "system", "content": legislation_finder_subagent_sys_prompt},
                 {"role": "user", "content": user},
             ]
         )
@@ -185,7 +159,7 @@ def _dispatch_subagents(
         if r.ok and r.value is not None:
             assessments.append(r.value)
         else:
-            url, _ = _extract_snippet(r.item)
+            url, _ = extract_url_and_snippet(r.item)
             assessments.append(
                 SourceAssessment(
                     url=url,
@@ -248,7 +222,7 @@ async def invoke_legislation_finder(city: str) -> dict:
     seen: set[str] = set()
     unique_candidates: list[str | dict[str, Any]] = []
     for c in candidates:
-        url, _ = _extract_snippet(c)
+        url, _ = extract_url_and_snippet(c)
         if url and url not in seen:
             seen.add(url)
             unique_candidates.append(c)
@@ -258,7 +232,7 @@ async def invoke_legislation_finder(city: str) -> dict:
 
     filtered_sources: list[str | dict[str, Any]] = []
     for c in unique_candidates:
-        url, _ = _extract_snippet(c)
+        url, _ = extract_url_and_snippet(c)
         if url in accepted_urls:
             filtered_sources.append(c)
 

--- a/agents/legislation_finder.py
+++ b/agents/legislation_finder.py
@@ -1,52 +1,61 @@
-"""Legislation finder agent for NV Local.
+"""Legislation finder — supervisor + per-source sub-agent architecture.
 
-Searches for recent local legislation for a given city using web search,
-and creates Google Calendar events for legislative dates via a remote MCP server.
+Tier A1 — graceful exit:
+    The discovery ReAct loop is driven by ``astream`` rather than ``ainvoke``
+    so that a ``GraphRecursionError`` returns whatever URLs have already been
+    accumulated in state, instead of erasing them.
+
+Tier A2 — supervisor / sub-agent split:
+    1. ``_run_discovery_agent`` — the original ReAct agent. Its sole job is
+       now to surface *candidate* URLs (via web_search) and optionally create
+       calendar events. It is the "discovery" layer of the supervisor.
+    2. ``_run_per_source_subagent`` — a bounded, stateless validator that
+       classifies one URL at a time and produces a ``SourceAssessment``.
+    3. ``invoke_legislation_finder`` is the supervisor: it runs discovery,
+       fans out per-source sub-agents through ``run_parallel``, and returns
+       both the filtered URL list and the per-source assessments so the
+       downstream pipeline can use them without re-running the ReAct loop.
+
+Keeping supervisor and sub-agent colocated per the plan's preference to keep
+related agent code in a single file.
 """
+
+from __future__ import annotations
 
 import logging
 import os
 from datetime import datetime, timedelta
+from typing import Any
 
 from langchain_mcp_adapters.tools import load_mcp_tools
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 from agents.base_agent_template import BaseReActAgent
+from config.constants import AGENT_RECURSION_LIMIT
 from config.system_prompts import legislation_finder_sys_prompt
+from utils.concurrency import run_parallel
+from utils.llm import get_structured_mini_llm
+from utils.schemas import LegislationFinderState, SourceAssessment
 from utils.tools import web_search
-from utils.schemas import LegislationFinderState
 
 logger = logging.getLogger(__name__)
 
 _GCAL_MCP_URL = "https://gcal.mintmcp.com/mcp"
+_TARGET_GCAL_TOOLS = {"create_event", "get_calendar_events", "update_event"}
 
 
-async def _load_gcal_tools():
-    """Load calendar tools from the remote Google Calendar MCP server."""
-    headers = {}
-    api_key = os.getenv("GLAMA_API_KEY")
-    if api_key:
-        headers["X-API-Key"] = api_key
+# ---------------------------------------------------------------------------
+# Discovery sub-layer — the original ReAct agent
+# ---------------------------------------------------------------------------
 
-    read, write, _ = await streamablehttp_client(
-        _GCAL_MCP_URL, headers=headers
-    ).__aenter__()
-    session = ClientSession(read, write)
-    await session.__aenter__()
-    await session.initialize()
-    tools = await load_mcp_tools(session)
-    return tools
-async def build_legislation_finder():
-    """Build the legislation finder agent with web_search + remote create_event."""
-    
-    gcal_tools = await _load_gcal_tools()
-    target_gcal_tools_name = {"create_event", "get_calendar_events", "update_event"}
-    selected_gcal_tools = [tool for tool in gcal_tools if tool.name in target_gcal_tools_name]
-    
+
+def _build_agent(gcal_tools: list) -> object:
+    """Build the discovery ReAct agent with web_search + (optional) calendar tools."""
+    selected = [t for t in gcal_tools if t.name in _TARGET_GCAL_TOOLS]
     agent = BaseReActAgent(
         state_schema=LegislationFinderState,
-        tools=[web_search, ] + selected_gcal_tools,
+        tools=[web_search] + selected,
         system_prompt=lambda state: legislation_finder_sys_prompt.format(
             input_city=state.get("city", "Unknown"),
             last_week_date=(datetime.today() - timedelta(days=7)).strftime("%B %d, %Y"),
@@ -54,3 +63,214 @@ async def build_legislation_finder():
         ),
     )
     return agent.build()
+
+
+async def _run_discovery_agent(graph, invoke_kwargs: dict) -> dict:
+    """Run the ReAct graph, tolerating recursion-limit exits gracefully.
+
+    Uses ``astream`` with ``stream_mode="values"`` so we see the full state
+    at each step. If LangGraph aborts with ``GraphRecursionError`` we still
+    return the most recent state snapshot — which contains any URLs the
+    agent had already accepted via web_search tool calls.
+    """
+    from langgraph.errors import GraphRecursionError
+
+    last_state: dict = {}
+    try:
+        async for state in graph.astream(
+            invoke_kwargs["input"],
+            config=invoke_kwargs["config"],
+            stream_mode="values",
+        ):
+            last_state = state or last_state
+    except GraphRecursionError:
+        partial_urls = last_state.get("legislation_sources", []) or []
+        logger.warning(
+            "Legislation finder hit recursion limit (%d steps); "
+            "returning %d partial URLs.",
+            invoke_kwargs["config"].get("recursion_limit", AGENT_RECURSION_LIMIT),
+            len(partial_urls),
+        )
+    return last_state
+
+
+# ---------------------------------------------------------------------------
+# Per-source sub-agent — bounded, stateless validator
+# ---------------------------------------------------------------------------
+
+
+_SUBAGENT_SYSTEM = """
+You are a per-source legislation validator. For the URL below, classify it
+and decide whether it meets the research quality bar.
+
+Accept criteria (any one is sufficient):
+  - Official government / municipal website (.gov, city portal, municode,
+    legistar, council agenda portal)
+  - Factual local-news reporting on specific legislation (no opinion language)
+  - Established wire service (AP, Reuters) with concrete legislative detail
+
+Reject:
+  - Opinion pieces, editorials, blog posts
+  - Aggregators that merely *mention* legislation without specifics
+  - Paywalled content you cannot verify
+  - Irrelevant domains (marketing, social media landing pages)
+
+Produce a single structured assessment. Do not browse; reason only from the
+URL + title/snippet context provided.
+""".strip()
+
+
+def _extract_snippet(item: str | dict[str, Any]) -> tuple[str, str]:
+    """Return (url, snippet) for a discovery item — string or pre-fetched dict."""
+    if isinstance(item, dict):
+        url = str(item.get("url", "")).strip()
+        snippet = (item.get("content") or "")[:800]
+        return url, snippet
+    return str(item).strip(), ""
+
+
+def _run_per_source_subagent(city: str, item: str | dict[str, Any]) -> SourceAssessment:
+    """Invoke the structured mini-LLM on one candidate URL.
+
+    Returns a :class:`SourceAssessment`. On LLM failure, falls back to a
+    reject decision rather than raising so the supervisor batch keeps going.
+    """
+    url, snippet = _extract_snippet(item)
+    if not url:
+        return SourceAssessment(url="", accepted=False, rationale="empty url")
+
+    llm = get_structured_mini_llm(SourceAssessment)
+    user = (
+        f"City: {city}\nURL: {url}\n"
+        f"Snippet (may be empty):\n{snippet or '(none)'}"
+    )
+    try:
+        result = llm.invoke(
+            [
+                {"role": "system", "content": _SUBAGENT_SYSTEM},
+                {"role": "user", "content": user},
+            ]
+        )
+        if isinstance(result, SourceAssessment):
+            assessment = result
+        elif isinstance(result, dict):
+            assessment = SourceAssessment(**result)
+        else:
+            assessment = SourceAssessment(
+                url=url,
+                accepted=False,
+                rationale=f"unexpected result type: {type(result).__name__}",
+            )
+        if not assessment.url:
+            assessment = assessment.model_copy(update={"url": url})
+        return assessment
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Sub-agent failed for %s: %s", url, exc)
+        return SourceAssessment(
+            url=url, accepted=False, rationale=f"subagent error: {exc}"
+        )
+
+
+def _dispatch_subagents(
+    city: str, candidates: list[str | dict[str, Any]]
+) -> list[SourceAssessment]:
+    """Fan out per-source validators in parallel and collect assessments."""
+    if not candidates:
+        return []
+    results = run_parallel(
+        lambda item: _run_per_source_subagent(city, item), candidates
+    )
+    assessments: list[SourceAssessment] = []
+    for r in results:
+        if r.ok and r.value is not None:
+            assessments.append(r.value)
+        else:
+            url, _ = _extract_snippet(r.item)
+            assessments.append(
+                SourceAssessment(
+                    url=url,
+                    accepted=False,
+                    rationale=f"dispatch error: {r.error!r}" if r.error else "no value",
+                )
+            )
+    return assessments
+
+
+# ---------------------------------------------------------------------------
+# Supervisor entry point
+# ---------------------------------------------------------------------------
+
+
+async def invoke_legislation_finder(city: str) -> dict:
+    """Supervisor: discover candidate URLs, then validate each in parallel.
+
+    Returns a dict matching the legacy shape (``legislation_sources``,
+    ``messages``, …) plus an added ``source_assessments`` list for callers
+    that want the per-source metadata.
+    """
+    from langchain_core.messages import HumanMessage
+
+    invoke_kwargs = {
+        "input": {
+            "city": city,
+            "messages": [
+                HumanMessage(content=f"Find recent legislation for {city}.")
+            ],
+        },
+        "config": {"recursion_limit": AGENT_RECURSION_LIMIT},
+    }
+
+    headers: dict[str, str] = {}
+    api_key = os.getenv("GLAMA_API_KEY")
+    if api_key:
+        headers["X-API-Key"] = api_key
+
+    try:
+        async with streamablehttp_client(_GCAL_MCP_URL, headers=headers) as (
+            read,
+            write,
+            _,
+        ):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                gcal_tools = await load_mcp_tools(session)
+                graph = _build_agent(gcal_tools)
+                discovery_state = await _run_discovery_agent(graph, invoke_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("MCP connection failed (%s); running without calendar tools", exc)
+        graph = _build_agent([])
+        discovery_state = await _run_discovery_agent(graph, invoke_kwargs)
+
+    candidates: list[str | dict[str, Any]] = (
+        discovery_state.get("legislation_sources", []) or []
+    )
+
+    seen: set[str] = set()
+    unique_candidates: list[str | dict[str, Any]] = []
+    for c in candidates:
+        url, _ = _extract_snippet(c)
+        if url and url not in seen:
+            seen.add(url)
+            unique_candidates.append(c)
+
+    assessments = _dispatch_subagents(city, unique_candidates)
+    accepted_urls = {a.url for a in assessments if a.accepted and a.url}
+
+    filtered_sources: list[str | dict[str, Any]] = []
+    for c in unique_candidates:
+        url, _ = _extract_snippet(c)
+        if url in accepted_urls:
+            filtered_sources.append(c)
+
+    logger.info(
+        "Legislation finder (%s): %d candidates → %d accepted by sub-agents.",
+        city,
+        len(unique_candidates),
+        len(filtered_sources),
+    )
+
+    return {
+        **discovery_state,
+        "legislation_sources": filtered_sources,
+        "source_assessments": [a.model_dump() for a in assessments],
+    }

--- a/config/constants.py
+++ b/config/constants.py
@@ -1,6 +1,30 @@
 """Pipeline-wide configuration constants."""
 
 # ---------------------------------------------------------------------------
+# Content retrieval — adaptive caps
+# ---------------------------------------------------------------------------
+
+# Hard ceiling on URLs fed to the content-retrieval step. Tavily Extract
+# itself can handle 20 URLs per batch; the tighter cap here bounds the
+# downstream LLM context, not the API.
+CONTENT_MAX_URLS: int = 10
+
+# Total character budget for raw (pre-compression) content across all URLs
+# in a single pipeline run. Per-URL allocation scales this by URL count.
+# At COMPRESSION_RATE=0.4 a 150K-char raw budget compresses to ~60K chars
+# (~15K tokens) for the note-taker — well inside the 272K-token input cap.
+CONTENT_TOTAL_CHAR_BUDGET: int = 150_000
+
+# Per-URL floor and ceiling to keep a small-city run from starving and a
+# content-rich URL from monopolizing the budget.
+CONTENT_MIN_CHARS_PER_URL: int = 5_000
+CONTENT_MAX_CHARS_PER_URL: int = 40_000
+
+# Default Tavily Search results per query.
+WEB_SEARCH_MAX_RESULTS: int = 5
+
+
+# ---------------------------------------------------------------------------
 # Context compression (LLMLingua-2)
 # ---------------------------------------------------------------------------
 

--- a/config/system_prompts/__init__.py
+++ b/config/system_prompts/__init__.py
@@ -1,13 +1,17 @@
 """Agent system system_prompts."""
 
 from config.system_prompts.compression import compression_instruction
-from config.system_prompts.legislation_finder import legislation_finder_sys_prompt
+from config.system_prompts.legislation_finder import (
+    legislation_finder_subagent_sys_prompt,
+    legislation_finder_sys_prompt,
+)
 from config.system_prompts.note_taker import note_taker_sys_prompt
 from config.system_prompts.reflection import reflection_prompt
 from config.system_prompts.writer import writer_sys_prompt
 
 __all__ = [
     "compression_instruction",
+    "legislation_finder_subagent_sys_prompt",
     "legislation_finder_sys_prompt",
     "note_taker_sys_prompt",
     "reflection_prompt",

--- a/config/system_prompts/legislation_finder.py
+++ b/config/system_prompts/legislation_finder.py
@@ -21,6 +21,16 @@ following conditions are met (whichever comes first):
 1. You have >= 3 findings, each backed by the required source minimum, AND you have completed the events search (Step 5).
 2. You have run 10 web_search calls (the hard limit).
 3. Your reflection returns next_action = "Research complete — compile final output."
+4. You have >= 1 accepted URL AND three consecutive reflections have surfaced
+   the same gap — further searches are unlikely to help. Compile whatever
+   partial findings you have and stop.
+
+## Partial Results Are Acceptable
+
+Every URL you emit via web_search is persisted to pipeline state the moment
+the tool call returns — downstream nodes can still use partial results if
+you exit early. Prefer emitting 1–2 solid sources over spiraling in pursuit
+of a 3rd that may not exist for small cities.
 
 Once a condition is met, write your final answer in the required output format and stop.
 

--- a/config/system_prompts/legislation_finder.py
+++ b/config/system_prompts/legislation_finder.py
@@ -127,3 +127,24 @@ If no qualifying legislation is found after exhausting your searches, respond wi
 - Never editorialize or assess whether legislation is "good" or "bad"
 - If a source requires a paywall to verify, note it as unverified and do not count it toward the source minimum
 """
+
+
+legislation_finder_subagent_sys_prompt = """
+You are a per-source legislation validator. For the URL below, classify it
+and decide whether it meets the research quality bar.
+
+Accept criteria (any one is sufficient):
+  - Official government / municipal website (.gov, city portal, municode,
+    legistar, council agenda portal)
+  - Factual local-news reporting on specific legislation (no opinion language)
+  - Established wire service (AP, Reuters) with concrete legislative detail
+
+Reject:
+  - Opinion pieces, editorials, blog posts
+  - Aggregators that merely *mention* legislation without specifics
+  - Paywalled content you cannot verify
+  - Irrelevant domains (marketing, social media landing pages)
+
+Produce a single structured assessment. Do not browse; reason only from the
+URL + title/snippet context provided.
+""".strip()

--- a/config/system_prompts/reflection.py
+++ b/config/system_prompts/reflection.py
@@ -60,6 +60,25 @@ Return a single raw JSON object. No markdown fences, no preamble.
 - If the conversation history is empty or contains no research activity yet: set `reflection` to `"No research conducted yet."`, `gaps_identified` to `[{{"severity": "CRITICAL", "gap": "No searches have been run — research has not started."}}]`, and `next_action` to the first recommended search query.
 - If all gaps are resolved, findings meet acceptance criteria, and any discovered events have been recorded via `create_event`: set `next_action` to `"Research complete — compile final output."` and `gaps_identified` to an empty array.
 
+## Mindful Reflection — Do Not Repeat Yourself
+
+Below are your prior reflections on this same research session. Use them to
+avoid thrashing:
+
+- Do NOT restate gaps that have already been resolved by subsequent tool calls.
+  If the history shows the gap was addressed, mark it resolved or omit it.
+- Do NOT repeat a `next_action` that was already executed. Pick a genuinely
+  different next step.
+- Focus `reflection` on what is *newly* known or *newly* missing since the
+  most recent prior entry — not a re-summary of the whole session.
+- If three consecutive prior reflections have shared a near-identical gap, the
+  research has likely saturated. Recommend compiling the final output rather
+  than looping further.
+
+<prior_reflections>
+{prior_reflections}
+</prior_reflections>
+
 ## Inputs
 
 <conversation_summary>

--- a/pipelines/node/content_retrieval.py
+++ b/pipelines/node/content_retrieval.py
@@ -10,6 +10,12 @@ import logging
 import httpx
 from langchain_core.runnables import RunnableLambda
 
+from config.constants import (
+    CONTENT_MAX_CHARS_PER_URL,
+    CONTENT_MAX_URLS,
+    CONTENT_MIN_CHARS_PER_URL,
+    CONTENT_TOTAL_CHAR_BUDGET,
+)
 from utils.async_runner import run_async
 from utils.content.compressor import compress_text
 from utils.tools.utils.extract import extract_url_content
@@ -55,10 +61,14 @@ def run_content_retrieval(inputs: ChainData) -> ChainData:
         return {**inputs, "legislation_content": []}
 
     # Cap URLs to avoid context overflow in downstream LLM calls.
-    # 20 content-rich pages (e.g. NYC) can exceed the 272K-token input limit
-    # even after LLMLingua-2 compression; 10 sources is ample for research quality.
-    ordered_urls = ordered_urls[:10]
+    ordered_urls = ordered_urls[:CONTENT_MAX_URLS]
     urls_to_fetch = [u for u in urls_to_fetch if u in set(ordered_urls)]
+
+    # Adaptive per-URL char budget: spread the total budget across the URLs
+    # we actually have. Small cities (few URLs) each get more context; large
+    # cities compress harder. Floors/ceilings prevent degenerate splits.
+    per_url_cap = CONTENT_TOTAL_CHAR_BUDGET // max(len(ordered_urls), 1)
+    per_url_cap = max(CONTENT_MIN_CHARS_PER_URL, min(CONTENT_MAX_CHARS_PER_URL, per_url_cap))
 
     # Fetch non-PDF URLs via Tavily Extract.
     url_to_content: dict[str, str] = {}
@@ -97,7 +107,10 @@ def run_content_retrieval(inputs: ChainData) -> ChainData:
             # Already compressed by the web_search tool — pass through.
             legislation_content.append(pre_fetched[url])
         elif url in url_to_content:
-            legislation_content.append(compress_text(url_to_content[url]))
+            raw = url_to_content[url]
+            if len(raw) > per_url_cap:
+                raw = raw[:per_url_cap]
+            legislation_content.append(compress_text(raw))
         else:
             legislation_content.append(f"[Failed to fetch: {url}]")
 

--- a/runners/run_container_job.py
+++ b/runners/run_container_job.py
@@ -8,7 +8,7 @@ import logging
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 try:
     from dotenv import load_dotenv
@@ -33,7 +33,6 @@ logger = logging.getLogger(__name__)
 
 
 def run_pipeline_instances(
-    pipeline_runner: Callable[[str, str], dict[str, Any]],
     targets: Sequence[tuple[str, str]],
 ) -> dict[tuple[str, str], dict[str, Any]]:
     """Execute one pipeline instance per (city, topic) target concurrently."""
@@ -46,7 +45,7 @@ def run_pipeline_instances(
 
     with ThreadPoolExecutor(max_workers=len(ordered_targets)) as executor:
         futures = {
-            executor.submit(pipeline_runner, city, topic): (city, topic)
+            executor.submit(run_pipeline, city, topic): (city, topic)
             for city, topic in ordered_targets
         }
 
@@ -101,7 +100,7 @@ def run_pipelines_for_cities_and_topics(
     """Execute the NV Local pipeline concurrently for all (city, topic) pairs."""
 
     targets = [(city, topic) for city in cities for topic in topics]
-    return run_pipeline_instances(run_pipeline, targets)
+    return run_pipeline_instances(targets)
 
 
 def render_city_topic_reports_markdown(
@@ -144,7 +143,7 @@ def main() -> int:
 
     # Run pipelines for all (city, topic) pairs
     targets = [(city, topic) for city in cities for topic in topics]
-    results = run_pipeline_instances(run_pipeline, targets)
+    results = run_pipeline_instances(targets)
     report = render_pipeline_reports_markdown(results, targets)
 
     if output_path:

--- a/utils/concurrency.py
+++ b/utils/concurrency.py
@@ -1,0 +1,122 @@
+"""Shared parallel execution helper.
+
+Provides a thin wrapper over ``ThreadPoolExecutor`` that:
+  - preserves input order in the returned results,
+  - captures per-item exceptions as structured ``Result`` entries instead of
+    crashing the whole batch,
+  - picks a sensible default worker count when callers don't specify one.
+
+Two variants are exposed: a sync ``run_parallel`` built on threads (correct
+for I/O-bound work and GIL-releasing C extensions like BERT forward passes)
+and an async ``run_parallel_async`` built on ``asyncio.gather`` (for async
+native callers such as the DeepL SDK if invoked via a coroutine wrapper).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Generic, Iterable, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+# Historical ceiling — original multi-city runs used 4 workers to avoid OOM.
+# Kept here as a named constant so callers that still need it can reference it
+# instead of re-hardcoding ``4``.
+LEGACY_MAX_WORKERS: int = 4
+
+
+@dataclass
+class Result(Generic[T, R]):
+    """Structured outcome for a single parallel job.
+
+    One of ``value`` or ``error`` is always set. ``index`` matches the caller's
+    input order so downstream code can reassemble position-sensitive payloads.
+    """
+
+    index: int
+    item: T
+    value: R | None = None
+    error: BaseException | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def _default_max_workers(item_count: int) -> int:
+    cpu = os.cpu_count() or 2
+    return max(1, min(item_count, cpu * 2))
+
+
+def run_parallel(
+    fn: Callable[[T], R],
+    items: Sequence[T] | Iterable[T],
+    max_workers: int | None = None,
+    timeout: float | None = None,
+) -> list[Result[T, R]]:
+    """Run ``fn`` over ``items`` in parallel threads.
+
+    Args:
+        fn: Callable invoked once per item.
+        items: Iterable of inputs. Materialized to a list to preserve order.
+        max_workers: Thread pool size. Defaults to ``min(len(items), cpu*2)``.
+        timeout: Optional per-future timeout (seconds).
+
+    Returns:
+        List of ``Result`` entries in the same order as ``items``.
+    """
+    items_list = list(items)
+    if not items_list:
+        return []
+
+    workers = max_workers if max_workers is not None else _default_max_workers(len(items_list))
+    results: list[Result[T, R]] = [
+        Result(index=i, item=item) for i, item in enumerate(items_list)
+    ]
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        future_to_idx = {
+            executor.submit(fn, item): i for i, item in enumerate(items_list)
+        }
+        for future in as_completed(future_to_idx, timeout=timeout):
+            idx = future_to_idx[future]
+            try:
+                results[idx].value = future.result()
+            except BaseException as exc:  # noqa: BLE001 — captured per-item
+                results[idx].error = exc
+
+    return results
+
+
+async def run_parallel_async(
+    fn: Callable[[T], Awaitable[R]],
+    items: Sequence[T] | Iterable[T],
+    concurrency: int | None = None,
+) -> list[Result[T, R]]:
+    """Run an async ``fn`` over ``items`` concurrently.
+
+    Uses a semaphore to cap concurrent coroutines. Per-item exceptions are
+    captured into ``Result.error`` rather than raised.
+    """
+    items_list = list(items)
+    if not items_list:
+        return []
+
+    limit = concurrency if concurrency is not None else _default_max_workers(len(items_list))
+    semaphore = asyncio.Semaphore(limit)
+
+    async def _run(i: int, item: T) -> Result[T, R]:
+        async with semaphore:
+            try:
+                value = await fn(item)
+                return Result(index=i, item=item, value=value)
+            except BaseException as exc:  # noqa: BLE001
+                return Result(index=i, item=item, error=exc)
+
+    coros = [_run(i, item) for i, item in enumerate(items_list)]
+    return list(await asyncio.gather(*coros))

--- a/utils/schemas/__init__.py
+++ b/utils/schemas/__init__.py
@@ -2,6 +2,7 @@
 
 from utils.schemas.pydantic import (
     ReflectionEntry,
+    SourceAssessment,
     WriterOutput,
 )
 from utils.schemas.state import (
@@ -12,6 +13,7 @@ from utils.schemas.state import (
 
 __all__ = [
     "ReflectionEntry",
+    "SourceAssessment",
     "WriterOutput",
     "BaseAgentState",
     "LegislationFinderState",

--- a/utils/schemas/pydantic.py
+++ b/utils/schemas/pydantic.py
@@ -22,6 +22,33 @@ class ReflectionEntry(BaseModel):
     )
 
 
+class SourceAssessment(BaseModel):
+    """Per-source structured output produced by a sub-agent validator.
+
+    Emitted by the supervisor's parallel fan-out step in the legislation
+    finder. Downstream code can accept/reject URLs without re-running the
+    monolithic ReAct loop for each candidate.
+    """
+
+    url: str = Field(description="Source URL being assessed")
+    accepted: bool = Field(
+        default=False,
+        description="Whether the source meets the pipeline's reliability bar",
+    )
+    source_type: Optional[str] = Field(
+        default=None,
+        description="Short classification: government, legislative, news, other, blocked",
+    )
+    headline: Optional[str] = Field(
+        default=None,
+        description="One-line summary of what the source covers, if determinable",
+    )
+    rationale: Optional[str] = Field(
+        default=None,
+        description="Short reason for the accept/reject decision",
+    )
+
+
 class WriterOutput(BaseModel):
     """Structured reflection output produced by the reflection tool."""
 

--- a/utils/schemas/state.py
+++ b/utils/schemas/state.py
@@ -5,7 +5,11 @@ from typing import NotRequired, Annotated, TypedDict
 import operator
 
 from langchain_core.messages import BaseMessage
-from utils.schemas.pydantic import ReflectionEntry, WriterOutput
+from utils.schemas.pydantic import (
+    ReflectionEntry,
+    SourceAssessment,
+    WriterOutput,
+)
 
 
 class BaseAgentState(TypedDict):
@@ -25,6 +29,8 @@ class LegislationFinderState(BaseAgentState):
     # Items are plain URL strings for HTML pages or dicts with pre-fetched
     # PDF content: {"url": str, "content": str, "source": "pdf"}.
     legislation_sources: NotRequired[Annotated[list[str | dict], operator.add]]
+    # Per-source outputs produced by the supervisor's parallel sub-agent pass.
+    source_assessments: NotRequired[list[SourceAssessment]]
 
 
 class ChainData(TypedDict):

--- a/utils/sources.py
+++ b/utils/sources.py
@@ -1,0 +1,30 @@
+"""Source-item normalization helpers.
+
+Pipeline state carries legislation sources as a heterogeneous list of either
+plain URL strings or pre-fetched dicts of the shape
+``{"url": str, "content": str, "source": "pdf"}``. Multiple call sites need
+to pull the URL (and sometimes a snippet) back out of that shape — this
+module centralizes that access so the str/dict branching lives in one place.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SourceItem = str | dict[str, Any]
+
+_SNIPPET_CHARS = 800
+
+
+def extract_url_and_snippet(item: SourceItem) -> tuple[str, str]:
+    """Return ``(url, snippet)`` for a source item.
+
+    For dict items the snippet is the first ``_SNIPPET_CHARS`` of the
+    pre-fetched ``content`` field (empty string if absent). For plain URL
+    strings the snippet is always empty.
+    """
+    if isinstance(item, dict):
+        url = str(item.get("url", "")).strip()
+        snippet = (item.get("content") or "")[:_SNIPPET_CHARS]
+        return url, snippet
+    return str(item).strip(), ""

--- a/utils/tools/reflection.py
+++ b/utils/tools/reflection.py
@@ -25,10 +25,32 @@ def _get_mini_model():
     return get_mini_llm()
 
 
+def _format_prior_reflections(prior: list[ReflectionEntry]) -> str:
+    """Render prior reflections compactly for injection into the mini-LLM prompt.
+
+    The renderer is tolerant of ``None`` / missing fields because early
+    reflections sometimes come back with sparse content.
+    """
+    if not prior:
+        return "No prior reflections."
+    lines: list[str] = []
+    for i, entry in enumerate(prior, 1):
+        reflection = (entry.reflection or "").strip() or "(empty)"
+        gaps = ", ".join(entry.gaps_identified) if entry.gaps_identified else "None"
+        next_action = (entry.next_action or "").strip() or "(none)"
+        lines.append(
+            f"{i}. reflection: {reflection}\n   gaps: {gaps}\n   next_action: {next_action}"
+        )
+    return "\n".join(lines)
+
+
 @tool
 def reflection_tool(
     tool_call_id: Annotated[str, InjectedToolCallId],
     messages: Annotated[list[BaseMessage], InjectedState("messages")],
+    prior_reflections: Annotated[
+        list[ReflectionEntry], InjectedState("reflection_list")
+    ] = None,
 ) -> Command:
     """Reflects on conversation history to determine the next action."""
 
@@ -39,6 +61,7 @@ def reflection_tool(
 
     formatted_prompt = reflection_prompt.format(
         conversation_summary=conversation_summary,
+        prior_reflections=_format_prior_reflections(prior_reflections or []),
     )
     response = _get_mini_model().invoke(
         [

--- a/utils/tools/web_search.py
+++ b/utils/tools/web_search.py
@@ -14,6 +14,7 @@ from langchain_core.tools import tool, InjectedToolCallId
 from langgraph.prebuilt.tool_node import InjectedState
 from langgraph.types import Command
 
+from config.constants import WEB_SEARCH_MAX_RESULTS
 from utils.content.compressor import compress_text
 from utils.content.pdf_extractor import is_pdf_url, download_and_parse_pdf
 from utils.tools._helpers import ok, err
@@ -51,7 +52,7 @@ async def web_search(
     query: str,
     tool_call_id: Annotated[str, InjectedToolCallId],
     city: Annotated[str, InjectedState("city")],
-    max_results: int = 5,
+    max_results: int = WEB_SEARCH_MAX_RESULTS,
 ) -> Command:
     """Search the web for legislation related to a specific municipality or topic.
 


### PR DESCRIPTION
## Summary
- **A1 — graceful exit:** legislation finder streams its ReAct loop via `astream` and catches `GraphRecursionError`, returning whatever URLs were accumulated instead of erasing partial progress. Prompt now flags that partial results are acceptable and adds a reflection-saturation exit condition.
- **A2 — supervisor/sub-agent:** `agents/legislation_finder.py` is now a supervisor that (1) runs the existing ReAct agent for discovery, (2) fans out per-source structured-output sub-agent validators via `run_parallel`, (3) returns `SourceAssessment` records alongside the filtered URL list.
- **A3 — mindful reflection:** `reflection_tool` now injects `reflection_list` from state and the prompt instructs the mini-LLM to skip resolved gaps, avoid repeating satisfied next-actions, and recommend compiling the final output once gaps saturate. `MAX_REFLECTION_ENTRIES` is now enforced in `BaseReActAgent._build_prompt`.
- **A4 — adaptive caps:** `content_retrieval` derives a per-URL char budget from `CONTENT_TOTAL_CHAR_BUDGET // url_count`, bounded by `CONTENT_MIN/MAX_CHARS_PER_URL`. `WEB_SEARCH_MAX_RESULTS` and `CONTENT_MAX_URLS` replace inline magic numbers.

Built on top of [#60](https://github.com/Next-Voters/Local/pull/60) (uses `utils.concurrency.run_parallel`). GitHub will auto-rebase once that lands.

## Test plan
- [x] `python -m compileall -q .`
- [ ] `python main.py <small-city>` — confirm legislation sources are still produced end-to-end.
- [ ] Spiral regression: force a known-bad `(city, topic)` that previously hit recursion_limit; verify the supervisor now returns ≥1 URL.
- [ ] Inspect `reflection_list` after a run — resolved/duplicate gaps should drop visibly.
- [ ] Verify `source_assessments` payload is populated in the final state dict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)