### PR TITLE
Newsletter-style email with structured legislation items

### DIFF
--- a/config/system_prompts/writer.py
+++ b/config/system_prompts/writer.py
@@ -1,47 +1,40 @@
 writer_sys_prompt = """
 ## Role
-You are an editor who transforms raw research notes into clean, scannable content for a general audience. You cut aggressively, simplify everything, and never editorialize.
+You are an editor who transforms raw research notes into clean, scannable legislation items for a general audience. You cut aggressively, simplify everything, and never editorialize.
 
 ## Task
-Convert the research notes provided into a structured summary using the output format below. Your only job is to extract what matters and present it clearly. Do not add information that isn't in the notes.
+Convert the research notes into a list of discrete legislation items. Each item represents one action, decision, or proposal found in the notes. Your only job is to extract what matters and present it clearly. Do not add information that isn't in the notes.
 
 ## Writing Rules
 - Use plain language. If a 10-year-old wouldn't understand a word, replace it.
-- Sentences must be under 20 words. Break anything longer into two sentences.
-- Every bullet must earn its place. If removing it loses no meaning, remove it.
+- Each item's header must be a short, specific, factual headline. No questions, no clickbait.
+- Each item's description must be 2-3 sentences. Sentences under 20 words.
 - Never open with filler: no "In conclusion," "It is worth noting," "Overall," or "This shows that."
 - Do not interpret or opine — report only what the notes say.
 
-## Output Format
-Produce exactly this structure, nothing more:
+## Output Structure
+Produce a list of items. Each item has:
+- **header**: One-line factual headline (e.g., "Council passes good cause eviction package")
+- **description**: 2-3 sentences explaining what happened, who voted, and what it means for residents
 
-**[Title]**
-One line. Specific and factual. No questions, no clickbait.
-
-- [Bullet 1]
-- [Bullet 2]
-- [Bullet 3]
-*(3–6 bullets total. Each bullet = one fact or finding. Max 25 words per bullet.)*
-
-**Takeaway:** [One sentence. The single most important thing a reader should remember.]
+Aim for 2-6 items. Each item = one distinct action or decision.
 
 ---
 
 ## Example
 
 **Input notes:**
-"City passed new zoning law last Tuesday. Allows mixed-use development in downtown core. Developers need 20% affordable units. Council vote was 7-2. Opponents said it'll gentrify the area. Takes effect Jan 1. Mayor called it a housing win."
+"City passed new zoning law last Tuesday. Allows mixed-use development in downtown core. Developers need 20% affordable units. Council vote was 7-2. Opponents said it'll gentrify the area. Takes effect Jan 1. Mayor called it a housing win. Separately, council approved $5M for road repairs on Main Street."
 
-**Correct output:**
+**Correct output (as structured items):**
 
-**Downtown Zoning Law Requires 20% Affordable Units in New Developments**
+Item 1:
+- header: "Downtown zoning law requires 20% affordable units in new developments"
+- description: "The city council passed a mixed-use zoning law for the downtown core, 7-2. All new developments must include at least 20% affordable housing units. The law takes effect January 1."
 
-- The city council passed a mixed-use zoning law for the downtown core, 7–2.
-- All new developments must include at least 20% affordable housing units.
-- The law takes effect January 1.
-- Critics raised concerns about gentrification; the mayor called it a housing win.
-
-**Takeaway:** The new downtown zoning law expands development rights while mandating affordable housing minimums starting January 1.
+Item 2:
+- header: "Council approves $5M for Main Street road repairs"
+- description: "Council approved $5 million in funding for road repairs on Main Street. The repairs address long-standing infrastructure concerns."
 
 ---
 
@@ -52,8 +45,8 @@ One line. Specific and factual. No questions, no clickbait.
 ---
 
 ## Edge Cases
-- If the notes are too thin to produce 3 bullets, write what you can and add a note: `[Note: Source material was limited — summary may be incomplete.]`
-- If the notes contain no clear facts (only opinions or speculation), respond with: `[Unable to summarize — no verifiable facts found in the provided notes.]`
+- If the notes are too thin to produce any items, return an empty items list.
+- If the notes contain no clear facts (only opinions or speculation), return an empty items list.
 - Do not ask clarifying questions. Work with what you have.
 
 The research notes to transform will be supplied in the next message.

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -141,36 +141,42 @@ def sample_legislation_notes() -> str:
 def sample_writer_output() -> dict[str, Any]:
     """Sample WriterOutput schema."""
     return {
-        "title": "Toronto City Council Legislation Update - January 2024",
-        "summary": "City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.",
-        "body": """- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030, mandates building retrofits, $50M renewable energy investment
-
-- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units in large developments, establishes $100M housing trust, implements income-based rent control
-
-- **Transit Expansion**: TTC approved Ontario Line expansion plan with federal and provincial funding
-
-- Key themes: Housing affordability and climate sustainability dominate 2024 legislative agenda""",
+        "items": [
+            {
+                "header": "Climate Action Initiative passed 38-7",
+                "description": "City Council passed Bill 1 establishing a 65% GHG reduction target by 2030. The bill mandates building retrofits and allocates $50M for renewable energy investment.",
+            },
+            {
+                "header": "Affordable Housing Strategy requires 20% affordable units",
+                "description": "Bill 2 passed 42-3, requiring 20% affordable units in large developments. It establishes a $100M housing trust and implements income-based rent control.",
+            },
+            {
+                "header": "TTC approves Ontario Line expansion plan",
+                "description": "The Toronto Transit Commission approved the Ontario Line expansion plan. The project will receive federal and provincial funding.",
+            },
+        ],
     }
 
 
 @pytest.fixture
 def sample_markdown_report() -> str:
     """Sample markdown report output."""
-    return """# Toronto City Council Legislation Update - January 2024
+    return """## ECONOMY & HOUSING
 
-## Summary
+**Climate Action Initiative passed 38-7**
+Toronto
 
-City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.
+City Council passed Bill 1 establishing a 65% GHG reduction target by 2030. The bill mandates building retrofits and allocates $50M for renewable energy investment.
 
-## Full Report
+**Affordable Housing Strategy requires 20% affordable units**
+Toronto
 
-- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030, mandates building retrofits, $50M renewable energy investment
+Bill 2 passed 42-3, requiring 20% affordable units in large developments. It establishes a $100M housing trust and implements income-based rent control.
 
-- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units in large developments, establishes $100M housing trust, implements income-based rent control
+**TTC approves Ontario Line expansion plan**
+Toronto
 
-- **Transit Expansion**: TTC approved Ontario Line expansion plan with federal and provincial funding
-
-- Key themes: Housing affordability and climate sustainability dominate 2024 legislative agenda
+The Toronto Transit Commission approved the Ontario Line expansion plan. The project will receive federal and provincial funding.
 """
 
 
@@ -186,9 +192,12 @@ def mock_llm_response() -> MagicMock:
 def mock_structured_llm_response() -> dict[str, Any]:
     """Mock structured LLM response (WriterOutput)."""
     return {
-        "title": "Toronto City Council Legislation Update",
-        "summary": "Summary of recent legislation.",
-        "body": "Bullet points of legislation details.",
+        "items": [
+            {
+                "header": "Toronto City Council Legislation Update",
+                "description": "Summary of recent legislation. Details of key decisions.",
+            },
+        ],
     }
 
 

--- a/evals/metrics/report_formatting.py
+++ b/evals/metrics/report_formatting.py
@@ -13,33 +13,33 @@ from deepeval.test_case import LLMTestCaseParams
 def report_formatting_criteria() -> str:
     return """Evaluate markdown report formatting and structure:
 
-    1. Required Sections Present:
-       - Title section (# header)
-       - Summary section (## Summary)
-       - Full Report section (## Full Report or similar)
-       - Politician Statements section (if applicable)
-    
+    1. Required Structure:
+       - ALL CAPS topic header (## TOPIC NAME)
+       - Bold item headers (**headline**)
+       - City/source line under each header
+       - Description paragraph (2-3 sentences) for each item
+
     2. Markdown Syntax Correctness:
-       - Proper header hierarchy (H1 > H2 > H3)
-       - Correct bullet point syntax (- or *)
+       - Proper ## headers for topic sections
+       - Bold **text** for item headlines
        - No broken markdown or rendering issues
        - Consistent formatting throughout
-    
+
     3. Content Organization:
-       - Logical flow from summary to details
-       - Clear separation between sections
-       - Easy navigation for readers
-    
+       - Items grouped under topic headers
+       - Clear separation between items
+       - Each item has header, source, and description
+
     4. Professional Quality:
        - Appropriate length for content
        - Readable formatting (not too dense/sparse)
        - Consistent styling choices
 
     Score Guidelines:
-    - 1.0: Perfect structure, all sections present, clean markdown
-    - 0.85: Minor formatting issues, all sections present
-    - 0.7: Most sections present, some formatting problems
-    - 0.5: Missing major sections, noticeable formatting issues
+    - 1.0: Perfect structure, topic headers, bold item headers, descriptions present
+    - 0.85: Minor formatting issues, all structure present
+    - 0.7: Most structure present, some formatting problems
+    - 0.5: Missing topic headers or item structure
     - 0.25: Major structural problems
     - 0.0: Not a valid report or completely unstructured"""
 
@@ -64,10 +64,8 @@ class SectionPresenceMetric(GEval):
         threshold: float = 1.0,
     ):
         self.required_sections = required_sections or [
-            "# Title",
-            "## Summary",
-            "## Full Report",
-            "## Politician",
+            "## TOPIC HEADER",
+            "**Item Header**",
         ]
         super().__init__(
             name="Section Presence",

--- a/evals/metrics/summary_quality.py
+++ b/evals/metrics/summary_quality.py
@@ -121,22 +121,24 @@ class SchemaComplianceMetric(GEval):
         )
 
     def _build_schema_criteria(self) -> str:
-        return """Validate that the output strictly follows the WriterOutput schema:
+        return """Validate that the output follows the structured legislation format:
 
-    Required fields:
-    - title: string (non-empty, descriptive title of the legislation)
-    - body: string (main content in bullet-point format)
-    - summary: string (brief summary of the content)
-    
+    Required structure:
+    - ALL CAPS topic header (## TOPIC NAME)
+    - One or more legislation items, each with:
+      - Bold header (**headline**)
+      - City/source line
+      - Description paragraph (2-3 sentences)
+
     Quality requirements:
-    - All three fields must be present
-    - title should be concise but descriptive
-    - body should be in bullet-point format
-    - summary should be 1-3 sentences maximum
-    
+    - Topic header must be present and in ALL CAPS
+    - Each item must have a bold header and description
+    - Descriptions should be 2-3 factual sentences
+    - Items should be clearly separated
+
     Score 1.0 only if ALL requirements met.
     Score 0.5 if minor formatting issues.
-    Score 0.0 if fields missing or fundamentally wrong format."""
+    Score 0.0 if structure missing or fundamentally wrong format."""
 
 
 def create_summary_quality_metric(

--- a/evals/test_e2e_pipeline.py
+++ b/evals/test_e2e_pipeline.py
@@ -138,15 +138,13 @@ class TestPipelineComponents:
         self, mock_invoke: MagicMock, sample_writer_output: dict[str, Any]
     ):
         """Test summary writer chain integration."""
-        from utils.schemas import WriterOutput
+        from utils.schemas import WriterOutput, LegislationItem
 
         mock_invoke.return_value = {
             "city": "Toronto",
             "notes": "test notes",
             "legislation_summary": WriterOutput(
-                title=sample_writer_output["title"],
-                summary=sample_writer_output["summary"],
-                body=sample_writer_output["body"],
+                items=[LegislationItem(**item) for item in sample_writer_output["items"]]
             ),
         }
 
@@ -167,12 +165,14 @@ class TestPipelineComponents:
         }
 
         from pipelines.node.report_formatter import report_formatter_chain
-        from utils.schemas import WriterOutput
+        from utils.schemas import WriterOutput, LegislationItem
 
         result = report_formatter_chain.invoke(
             {
+                "city": "Toronto",
+                "topic": "Economy",
                 "legislation_summary": WriterOutput(
-                    title="Test", summary="Test", body="Test"
+                    items=[LegislationItem(header="Test", description="Test description.")]
                 ),
             }
         )
@@ -211,9 +211,8 @@ class TestPipelineOutput:
 
     def test_report_contains_expected_structure(self, sample_markdown_report: str):
         """Test that report has expected markdown structure."""
-        assert "# " in sample_markdown_report
         assert "## " in sample_markdown_report
-        assert sample_markdown_report.count("#") >= 2
+        assert "**" in sample_markdown_report
 
 
 class TestPipelineIntegration:
@@ -229,15 +228,13 @@ class TestPipelineIntegration:
         sample_writer_output: dict[str, Any],
     ):
         """Test complete pipeline with all mocks."""
-        from utils.schemas import WriterOutput
+        from utils.schemas import WriterOutput, LegislationItem
 
         mock_search.return_value = {
             "web": {"results": [{"title": "Test", "url": "https://test.com"}]}
         }
         mock_model.return_value.invoke.return_value = WriterOutput(
-            title=sample_writer_output["title"],
-            summary=sample_writer_output["summary"],
-            body=sample_writer_output["body"],
+            items=[LegislationItem(**item) for item in sample_writer_output["items"]]
         )
 
         from pipelines.nv_local import run_pipeline

--- a/evals/test_report_formatter.py
+++ b/evals/test_report_formatter.py
@@ -19,7 +19,7 @@ from evals.metrics.report_formatting import (
     MarkdownSyntaxMetric,
     create_report_formatting_metric,
 )
-from utils.schemas import ChainData, WriterOutput
+from utils.schemas import ChainData, WriterOutput, LegislationItem
 
 
 class TestReportFormatter:
@@ -42,10 +42,10 @@ class TestReportFormatter:
         from pipelines.node.report_formatter import report_formatter
 
         inputs: ChainData = {
+            "city": "Toronto",
+            "topic": "Economy & Housing",
             "legislation_summary": WriterOutput(
-                title=sample_writer_output["title"],
-                summary=sample_writer_output["summary"],
-                body=sample_writer_output["body"],
+                items=[LegislationItem(**item) for item in sample_writer_output["items"]]
             ),
         }
 
@@ -66,26 +66,32 @@ class TestReportFormatter:
         result = report_formatter(inputs)
 
         assert "markdown_report" in result
-        assert "No Legislation Found" in result["markdown_report"]
+        assert result["markdown_report"] == ""
 
     def test_report_includes_required_sections(self):
-        """Test that report includes all required sections."""
+        """Test that report includes topic header and item structure."""
         from pipelines.node.report_formatter import report_formatter
 
         inputs: ChainData = {
+            "city": "Toronto",
+            "topic": "Economy & Housing",
             "legislation_summary": WriterOutput(
-                title="Test Title",
-                summary="Test summary",
-                body="Test body content",
+                items=[
+                    LegislationItem(
+                        header="Test legislation headline",
+                        description="This is a test description of legislation.",
+                    )
+                ]
             ),
         }
 
         result = report_formatter(inputs)
         report = result["markdown_report"]
 
-        assert "# Test Title" in report
-        assert "## Summary" in report
-        assert "## Full Report" in report
+        assert "## ECONOMY & HOUSING" in report
+        assert "**Test legislation headline**" in report
+        assert "Toronto" in report
+        assert "This is a test description" in report
 
 
 class TestReportFormattingMetric:
@@ -99,14 +105,17 @@ class TestReportFormattingMetric:
         """Test metric scores high for well-formatted report."""
         test_case = LLMTestCase(
             input="Generate report for Toronto legislation",
-            actual_output="""# Toronto City Council Legislation Update
+            actual_output="""## ECONOMY & HOUSING
 
-## Summary
-City Council passed major climate and housing legislation in January 2024.
+**Climate Action Initiative passed 38-7**
+Toronto
 
-## Full Report
-- **Bill 1-2024**: Climate Action Initiative
-- **Bill 2-2024**: Affordable Housing Strategy
+City Council passed Bill 1 establishing a 65% GHG reduction target by 2030. The bill mandates building retrofits.
+
+**Affordable Housing Strategy requires 20% affordable units**
+Toronto
+
+Bill 2 passed 42-3, requiring 20% affordable units in large developments.
 """,
         )
 
@@ -131,9 +140,7 @@ Just some bullet points
         """Test metric detects missing required sections."""
         test_case = LLMTestCase(
             input="Generate report",
-            actual_output="""# Title
-
-Just some content without proper section headers.""",
+            actual_output="""Just some content without proper section headers or item structure.""",
         )
 
         self.metric.measure(test_case)
@@ -147,21 +154,19 @@ class TestSectionPresenceMetric:
         """Test detection of all required sections."""
         metric = SectionPresenceMetric(
             required_sections=[
-                "# Title",
-                "## Summary",
-                "## Full Report",
+                "## TOPIC HEADER",
+                "**Item Header**",
             ]
         )
 
         test_case = LLMTestCase(
             input="Generate report",
-            actual_output="""# Toronto Legislation
+            actual_output="""## ECONOMY & HOUSING
 
-## Summary
-Summary content here.
+**Climate Action Initiative passed 38-7**
+Toronto
 
-## Full Report
-Report content here.
+City Council passed Bill 1 establishing a 65% GHG reduction target.
 """,
         )
 
@@ -171,17 +176,12 @@ Report content here.
     def test_missing_sections(self):
         """Test detection of missing sections."""
         metric = SectionPresenceMetric(
-            required_sections=["# Title", "## Summary", "## Full Report"]
+            required_sections=["## TOPIC HEADER", "**Item Header**"]
         )
 
         test_case = LLMTestCase(
             input="Generate report",
-            actual_output="""# Title
-
-## Summary
-Summary here.
-
-Missing Full Report section.""",
+            actual_output="""Some text without proper topic headers or bold item headers.""",
         )
 
         metric.measure(test_case)
@@ -191,18 +191,20 @@ Missing Full Report section.""",
         """Test custom required sections."""
         metric = SectionPresenceMetric(
             required_sections=[
-                "# Executive Summary",
-                "## Legislation",
+                "## TOPIC HEADER",
+                "**Item Header**",
             ]
         )
 
         test_case = LLMTestCase(
             input="Generate report",
-            actual_output="""# Executive Summary
-Content
+            actual_output="""## TRANSPORTATION
 
-## Legislation
-Content""",
+**New bus routes approved for downtown**
+Toronto
+
+Three new bus routes will serve the downtown core starting March 1.
+""",
         )
 
         metric.measure(test_case)
@@ -218,23 +220,27 @@ class TestMarkdownSyntaxMetric:
 
         test_case = LLMTestCase(
             input="Generate report",
-            actual_output="""# Title
+            actual_output="""## ECONOMY & HOUSING
 
-## Section 1
+**Council passes eviction package**
+Toronto
 
-- Bullet point 1
-- Bullet point 2
+The Council voted 48-18 to extend tenant protections.
 
-**Bold text** and *italic text*
+**Albany advances FAB cap reform**
+New York State
 
-[Link text](https://example.com)
+A-1234 heard in committee 12-4.
 
 ---
 
-### Subsection
+## TRANSPORTATION
 
-1. Numbered item 1
-2. Numbered item 2""",
+**New subway line approved**
+Toronto
+
+The TTC approved the Ontario Line expansion.
+""",
         )
 
         metric.measure(test_case)
@@ -266,10 +272,10 @@ class TestReportFormatterIntegration:
         from pipelines.node.report_formatter import report_formatter
 
         inputs: ChainData = {
+            "city": "Toronto",
+            "topic": "Economy & Housing",
             "legislation_summary": WriterOutput(
-                title=sample_writer_output["title"],
-                summary=sample_writer_output["summary"],
-                body=sample_writer_output["body"],
+                items=[LegislationItem(**item) for item in sample_writer_output["items"]]
             ),
         }
 
@@ -278,58 +284,66 @@ class TestReportFormatterIntegration:
 
         assert isinstance(report, str)
         assert len(report) > 100
-        assert report.startswith("#")
+        assert report.startswith("##")
 
 
 class TestReportFormatterEdgeCases:
     """Edge case tests for report formatter."""
 
-    def test_empty_title(self):
-        """Test handling of empty title."""
+    def test_empty_items(self):
+        """Test handling of empty items list."""
         from pipelines.node.report_formatter import report_formatter
 
         inputs: ChainData = {
-            "legislation_summary": WriterOutput(
-                title="",
-                summary="Summary",
-                body="Body",
-            ),
+            "city": "Toronto",
+            "topic": "Economy",
+            "legislation_summary": None,
         }
 
         result = report_formatter(inputs)
         assert "markdown_report" in result
+        assert result["markdown_report"] == ""
 
-    def test_very_long_content(self):
-        """Test handling of very long content."""
+    def test_single_item(self):
+        """Test handling of a single legislation item."""
         from pipelines.node.report_formatter import report_formatter
 
-        long_body = "x" * 10000
-
         inputs: ChainData = {
+            "city": "Toronto",
+            "topic": "Housing",
             "legislation_summary": WriterOutput(
-                title="Long Report",
-                summary="A very long summary " * 100,
-                body=long_body,
+                items=[
+                    LegislationItem(
+                        header="New housing bill passed",
+                        description="The council approved a new housing bill.",
+                    )
+                ]
             ),
         }
 
         result = report_formatter(inputs)
-        assert len(result["markdown_report"]) > 10000
+        assert "## HOUSING" in result["markdown_report"]
+        assert "**New housing bill passed**" in result["markdown_report"]
 
-    def test_special_characters_in_title(self):
-        """Test handling of special characters in titles."""
+    def test_special_characters_in_header(self):
+        """Test handling of special characters in headers."""
         from pipelines.node.report_formatter import report_formatter
 
         inputs: ChainData = {
+            "city": "Toronto",
+            "topic": "Economy",
             "legislation_summary": WriterOutput(
-                title="Test: Special Chars & More (#1)",
-                summary="Summary with special chars",
-                body="- Point with **bold** and *italic*",
+                items=[
+                    LegislationItem(
+                        header="Test: Special Chars & More (#1)",
+                        description="Description with special chars.",
+                    )
+                ]
             ),
         }
 
         result = report_formatter(inputs)
-        assert "# Test:" in result["markdown_report"]
+        assert "**Test: Special Chars & More (#1)**" in result["markdown_report"]
 
 
 def run_report_formatter_evaluation() -> dict[str, Any]:
@@ -343,15 +357,17 @@ def run_report_formatter_evaluation() -> dict[str, Any]:
     test_cases = [
         LLMTestCase(
             input="Generate markdown report for Toronto legislation",
-            actual_output="""# Toronto City Council Legislation Update - January 2024
+            actual_output="""## ECONOMY & HOUSING
 
-## Summary
-City Council passed significant climate action and housing legislation including a 65% GHG reduction target and mandatory affordable housing requirements.
+**Climate Action Initiative passed 38-7**
+Toronto
 
-## Full Report
-- **Climate Action Initiative (Bill 1)**: Passed 38-7, establishes 65% GHG reduction target by 2030, mandates building retrofits, $50M renewable energy investment
+City Council passed Bill 1 establishing a 65% GHG reduction target by 2030. The bill mandates building retrofits and allocates $50M for renewable energy.
 
-- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, requires 20% affordable units in large developments, establishes $100M housing trust, implements income-based rent control
+**Affordable Housing Strategy requires 20% affordable units**
+Toronto
+
+Bill 2 passed 42-3, requiring 20% affordable units in large developments. It establishes a $100M housing trust.
 """,
         ),
         LLMTestCase(

--- a/evals/test_summary_writer.py
+++ b/evals/test_summary_writer.py
@@ -23,7 +23,7 @@ from evals.metrics.no_hallucination import (
     NoHallucinationMetric,
     ClaimVerifiabilityMetric,
 )
-from utils.schemas import WriterOutput
+from utils.schemas import WriterOutput, LegislationItem
 
 
 class TestSummaryWriter:
@@ -39,22 +39,23 @@ class TestSummaryWriter:
     def test_writer_output_schema_validation(self):
         """Test WriterOutput schema correctly validates output."""
         valid_output = WriterOutput(
-            title="Test Title",
-            summary="Test summary",
-            body="Test body content",
+            items=[
+                LegislationItem(
+                    header="Test headline",
+                    description="Test description of legislation.",
+                )
+            ]
         )
 
-        assert valid_output.title == "Test Title"
-        assert valid_output.summary == "Test summary"
-        assert valid_output.body == "Test body content"
+        assert len(valid_output.items) == 1
+        assert valid_output.items[0].header == "Test headline"
+        assert valid_output.items[0].description == "Test description of legislation."
 
     def test_writer_output_optional_fields(self):
-        """Test WriterOutput handles optional fields correctly."""
+        """Test WriterOutput handles empty items list correctly."""
         minimal_output = WriterOutput()
 
-        assert minimal_output.title is None
-        assert minimal_output.summary is None
-        assert minimal_output.body is None
+        assert minimal_output.items == []
 
     @patch("pipelines.node.summary_writer._get_model")
     def test_summary_writer_produces_valid_schema(
@@ -64,9 +65,16 @@ class TestSummaryWriter:
     ):
         """Test that summary writer produces valid WriterOutput."""
         mock_model.return_value.invoke.return_value = WriterOutput(
-            title="Toronto Legislation Update",
-            summary="City Council passed climate and housing legislation.",
-            body="- Climate Action: 65% GHG reduction\n- Housing: 20% affordable units",
+            items=[
+                LegislationItem(
+                    header="Climate Action Initiative passed 38-7",
+                    description="City Council passed Bill 1 establishing a 65% GHG reduction target by 2030.",
+                ),
+                LegislationItem(
+                    header="Affordable Housing Strategy requires 20% affordable units",
+                    description="Bill 2 passed 42-3, requiring 20% affordable units in large developments.",
+                ),
+            ]
         )
 
         from pipelines.node.summary_writer import research_summary_writer
@@ -78,21 +86,17 @@ class TestSummaryWriter:
         assert "legislation_summary" in result
         summary = result["legislation_summary"]
         assert summary is not None
-        assert summary.title is not None
-        assert summary.summary is not None
-        assert summary.body is not None
+        assert len(summary.items) == 2
+        assert summary.items[0].header is not None
+        assert summary.items[0].description is not None
 
     @patch("pipelines.node.summary_writer._get_model")
     def test_summary_writer_handles_no_content(
         self,
         mock_model: MagicMock,
     ):
-        """Test that summary writer handles empty notes gracefully."""
-        mock_model.return_value.invoke.return_value = WriterOutput(
-            title="No Content",
-            summary=None,
-            body=None,
-        )
+        """Test that summary writer handles empty items gracefully."""
+        mock_model.return_value.invoke.return_value = WriterOutput(items=[])
 
         from pipelines.node.summary_writer import research_summary_writer
         from utils.schemas import ChainData
@@ -101,6 +105,7 @@ class TestSummaryWriter:
         result = research_summary_writer(inputs)
 
         assert "legislation_summary" in result
+        assert result["legislation_summary"] is None
 
 
 class TestSummaryQualityMetric:
@@ -114,15 +119,17 @@ class TestSummaryQualityMetric:
         """Test metric scores high for quality summary."""
         test_case = LLMTestCase(
             input="Summarize the legislation for Toronto",
-            actual_output="""## Toronto City Council Legislation Update
+            actual_output="""## ECONOMY & HOUSING
 
-### Summary
-City Council passed two major bills: Climate Action Initiative (Bill 1) targeting 65% GHG reduction by 2030, and Affordable Housing Strategy (Bill 2) requiring 20% affordable units in new developments.
+**Climate Action Initiative passed 38-7**
+Toronto
 
-### Key Points
-- **Climate Bill (Bill 1)**: Passed 38-7, $50M renewable energy investment
-- **Housing Bill (Bill 2)**: Passed 42-3, $100M housing trust established
-- Both bills align with council priorities for 2024""",
+City Council passed Bill 1 targeting 65% GHG reduction by 2030. The bill mandates building retrofits and allocates $50M for renewable energy investment.
+
+**Affordable Housing Strategy requires 20% affordable units**
+Toronto
+
+Bill 2 passed 42-3, requiring 20% affordable units in new developments. It establishes a $100M housing trust and implements income-based rent control.""",
             retrieval_context=mock_retrieval_context,
         )
 
@@ -173,27 +180,29 @@ class TestSchemaComplianceMetric:
 
         test_case = LLMTestCase(
             input="Summarize the legislation",
-            actual_output="""# Title of Legislation
+            actual_output="""## ECONOMY & HOUSING
 
-## Summary
-Brief 1-2 sentence summary of the legislation.
+**Council passes eviction package**
+Toronto
 
-## Details
-- Point 1
-- Point 2
-- Point 3""",
+The Council voted 48-18 to extend tenant protections to 1.6 million market-rate units.
+
+**Albany advances FAB cap reform**
+New York State
+
+A-1234 heard in committee 12-4, lifting the 12.0 five-acre-minimum cap.""",
         )
 
         metric.measure(test_case)
         assert metric.score >= 0.8
 
-    def test_missing_title(self):
-        """Test detection of missing title."""
+    def test_missing_topic_header(self):
+        """Test detection of missing topic header."""
         metric = SchemaComplianceMetric()
 
         test_case = LLMTestCase(
             input="Summarize the legislation",
-            actual_output="""Summary of legislation content here.
+            actual_output="""Some content without topic header or item structure.
 
 Details:
 - Point 1
@@ -203,16 +212,15 @@ Details:
         metric.measure(test_case)
         assert metric.score < 1.0
 
-    def test_missing_body(self):
-        """Test detection of missing body."""
+    def test_missing_item_structure(self):
+        """Test detection of missing item structure."""
         metric = SchemaComplianceMetric()
 
         test_case = LLMTestCase(
             input="Summarize the legislation",
-            actual_output="""# Title of Legislation
+            actual_output="""## ECONOMY & HOUSING
 
-## Summary
-Brief summary of the legislation.""",
+Just a paragraph of text without bold headers or item structure.""",
         )
 
         metric.measure(test_case)
@@ -228,9 +236,13 @@ class TestSummaryWriterEdgeCases:
         long_notes = "Point " * 1000
 
         mock_model.return_value.invoke.return_value = WriterOutput(
-            title="Long Document Summary",
-            summary="Concise summary of lengthy content.",
-            body="- " + "\n- ".join([f"Point {i}" for i in range(50)]),
+            items=[
+                LegislationItem(
+                    header=f"Point {i} summary",
+                    description=f"Details about point {i}.",
+                )
+                for i in range(5)
+            ]
         )
 
         from pipelines.node.summary_writer import research_summary_writer
@@ -245,45 +257,48 @@ class TestSummaryWriterEdgeCases:
     def test_unicode_content(self, mock_model: MagicMock):
         """Test handling of unicode characters."""
         mock_model.return_value.invoke.return_value = WriterOutput(
-            title="Café and Restaurant Regulations",
-            summary="New regulations for café outdoor seating in Toronto.",
-            body="- Unicode: café, naïve, résumé\n- Special chars: © ® ™",
+            items=[
+                LegislationItem(
+                    header="Cafe and Restaurant Regulations",
+                    description="New regulations for cafe outdoor seating in Toronto. The rules cover patio permits and noise limits.",
+                )
+            ]
         )
 
         from pipelines.node.summary_writer import research_summary_writer
         from utils.schemas import ChainData
 
-        inputs: ChainData = {"notes": "Café regulations: Unicode content"}
+        inputs: ChainData = {"notes": "Cafe regulations: Unicode content"}
         result = research_summary_writer(inputs)
 
         assert result["legislation_summary"] is not None
-        assert "café" in result["legislation_summary"].title.lower()
+        assert "Cafe" in result["legislation_summary"].items[0].header
 
     @patch("pipelines.node.summary_writer._get_model")
-    def test_no_legislation_patterns(self, mock_model: MagicMock):
-        """Test that 'no legislation' patterns are handled."""
-        no_content_patterns = [
-            "No Content",
-            "No Recent Legislation",
-            "None",
-            "N/A",
-            "no recent legislation found",
-        ]
+    def test_empty_items_returns_none(self, mock_model: MagicMock):
+        """Test that empty items list triggers None return."""
+        mock_model.return_value.invoke.return_value = WriterOutput(items=[])
 
         from pipelines.node.summary_writer import research_summary_writer
         from utils.schemas import ChainData
 
-        for pattern in no_content_patterns:
-            mock_model.return_value.invoke.return_value = WriterOutput(
-                title=pattern,
-                summary="No content",
-                body="No body",
-            )
+        inputs: ChainData = {"notes": "Some notes"}
+        result = research_summary_writer(inputs)
 
-            inputs: ChainData = {"notes": "Some notes"}
-            result = research_summary_writer(inputs)
+        assert result["legislation_summary"] is None
 
-            assert result["legislation_summary"] is None
+    @patch("pipelines.node.summary_writer._get_model")
+    def test_none_response_returns_none(self, mock_model: MagicMock):
+        """Test that None LLM response triggers None return."""
+        mock_model.return_value.invoke.return_value = None
+
+        from pipelines.node.summary_writer import research_summary_writer
+        from utils.schemas import ChainData
+
+        inputs: ChainData = {"notes": "Some notes"}
+        result = research_summary_writer(inputs)
+
+        assert result["legislation_summary"] is None
 
 
 class TestMultiDimensionalSummaryMetric:
@@ -351,15 +366,17 @@ def run_summary_writer_evaluation() -> dict[str, Any]:
     test_cases = [
         LLMTestCase(
             input="Summarize Toronto legislation for January 2024",
-            actual_output="""# Toronto City Council Legislation Update
+            actual_output="""## ECONOMY & HOUSING
 
-## Summary
-City Council passed two significant bills: Climate Action Initiative (Bill 1) establishing 65% GHG reduction target and Affordable Housing Strategy (Bill 2) requiring 20% affordable units in new developments.
+**Climate Action Initiative passed 38-7**
+Toronto
 
-## Full Report
-- **Climate Action Initiative (Bill 1)**: Passed 38-7, 65% GHG reduction by 2030, $50M renewable investment
-- **Affordable Housing Strategy (Bill 2)**: Passed 42-3, 20% affordable units, $100M housing trust
-- Both bills represent major council priorities for 2024""",
+City Council passed Bill 1 establishing a 65% GHG reduction target by 2030. The bill mandates building retrofits and allocates $50M for renewable energy.
+
+**Affordable Housing Strategy requires 20% affordable units**
+Toronto
+
+Bill 2 passed 42-3, requiring 20% affordable units in large developments. It establishes a $100M housing trust.""",
             retrieval_context=retrieval_context,
         ),
         LLMTestCase(

--- a/pipelines/node/email_dispatcher.py
+++ b/pipelines/node/email_dispatcher.py
@@ -202,11 +202,19 @@ def dispatch_emails_to_subscribers(
         sections_html = build_all_topic_sections_html(topic_html_pairs, referral_code=referral_code, city=city)
         social_share_urls = build_social_share_urls(referral_code=referral_code)
         toc_html = build_table_of_contents_html(topic_names)
+
+        intro = (
+            f"Here\u2019s what {city}, the statehouse, and Washington actually did this "
+            f"week \u2014 organized by topic, every claim cited."
+        )
+
         html_body = render_template(
             "",
             topic_sections_html=sections_html,
             social_share_urls=social_share_urls,
             table_of_contents_html=toc_html,
+            greeting="Good morning, New Voters.",
+            intro=intro,
         )
 
         send_queue.append({
@@ -257,7 +265,7 @@ def dispatch_emails_to_subscribers(
                         send_single_email,
                         pool,
                         item["contact"],
-                        f"NV Local Report - {item['city']}",
+                        f"Your {item['city']} brief \u2014 city, state, and Congress this week",
                         item["html_body"],
                         failures_queue,
                     )

--- a/pipelines/node/report_formatter.py
+++ b/pipelines/node/report_formatter.py
@@ -3,38 +3,27 @@ from langchain_core.runnables import RunnableLambda
 from utils.schemas import ChainData
 
 
-def _safe_text(value: object, fallback: str) -> str:
-    if isinstance(value, str):
-        text = value.strip()
-        return text or fallback
-    return fallback
-
-
 def report_formatter(inputs: ChainData) -> ChainData:
+    """Format legislation items into topic-organized markdown."""
     legislation_summary = inputs.get("legislation_summary")
+    topic = inputs.get("topic", "General")
+    city = inputs.get("city", "")
 
     if legislation_summary is None:
         return {
             **inputs,
-            "markdown_report": "# No Legislation Found\n\nNo recent legislation was found for the specified city. Try a different city or check back later for updates.",
+            "markdown_report": "",
         }
 
-    title = _safe_text(legislation_summary.title, "Untitled Report")
-    summary = _safe_text(legislation_summary.summary, "No summary available.")
-    body = _safe_text(legislation_summary.body, "No detailed report available.")
+    lines = [f"## {topic.upper()}", ""]
 
-    lines = [
-        f"# {title}",
-        "",
-        "## Summary",
-        "",
-        summary,
-        "",
-        "## Full Report",
-        "",
-        body,
-        "",
-    ]
+    for item in legislation_summary.items:
+        lines.append(f"**{item.header}**")
+        if city:
+            lines.append(city)
+        lines.append("")
+        lines.append(item.description)
+        lines.append("")
 
     raw_sources = inputs.get("legislation_sources") or []
     source_urls = [

--- a/pipelines/node/summary_writer.py
+++ b/pipelines/node/summary_writer.py
@@ -24,19 +24,7 @@ def research_summary_writer(inputs: ChainData) -> ChainData:
         ],
     )
 
-    if ai_generated_summary is None:
-        return {**inputs, "legislation_summary": None}
-
-    title_lower = (
-        ai_generated_summary.title.lower().strip() if ai_generated_summary.title else ""
-    )
-    no_title_patterns = ("no content", "no recent", "no legislation", "none", "")
-
-    if (
-        title_lower in no_title_patterns
-        or title_lower.startswith("no ")
-        or title_lower.startswith("n/a")
-    ):
+    if ai_generated_summary is None or not ai_generated_summary.items:
         return {**inputs, "legislation_summary": None}
 
     return {**inputs, "legislation_summary": ai_generated_summary}

--- a/templates/email_report.html
+++ b/templates/email_report.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NV - Next Voters Report</title>
+    <title>Next Voters Brief</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,700&display=swap" rel="stylesheet">
@@ -17,48 +17,21 @@
     <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#F5F5F0">
         <tr>
             <td align="center" style="padding: 20px 10px;">
-                <!-- PREHEADER -->
-                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="max-width: 600px;">
-                    <tr>
-                        <td style="font-size: 1px; line-height: 1px; color: #F5F5F0;">&nbsp;</td>
-                    </tr>
-                </table>
-
                 <!-- MAIN CONTAINER -->
                 <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="max-width: 600px; background-color: #FFFFFF; border-collapse: collapse;">
                     <!-- HEADER -->
                     <tr>
-                        <td style="background-color: #E63946; padding: 0;">
-                            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-                                <tr>
-                                    <td style="padding: 30px 30px 20px 30px; text-align: center;">
-                                        <!-- NV LOGO / BRANDING -->
-                                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-                                            <tr>
-                                                <td align="center">
-                                                    <span style="font-family: 'Bebas Neue', Impact, sans-serif; font-size: 72px; color: #FFFFFF; letter-spacing: 4px; line-height: 1; display: block;">NV</span>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td align="center" style="padding-top: 8px;">
-                                                    <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 11px; color: #FFFFFF; letter-spacing: 6px; text-transform: uppercase; font-weight: 500;">Next Voters</span>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="background-color: #1A1A1A; padding: 12px 30px;">
-                                        <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; color: #FFFFFF; margin: 0; text-align: center; letter-spacing: 1px; font-weight: 500;">YOUR LOCAL ELECTION REPORT</p>
-                                    </td>
-                                </tr>
-                            </table>
+                        <td style="padding: 30px 35px 10px 35px;">
+                            <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; color: #E63946; font-weight: 700; letter-spacing: 1px;">NEXT VOTERS</span>
                         </td>
                     </tr>
 
-                    <!-- ACCENT BORDER -->
+                    <!-- GREETING & INTRO -->
                     <tr>
-                        <td style="height: 6px; background-color: #E63946; border-bottom: 3px solid #1A1A1A;"></td>
+                        <td style="padding: 10px 35px 5px 35px;">
+                            <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 15px; color: #1A1A1A; margin: 0 0 10px 0; line-height: 1.6;">{{GREETING}}</p>
+                            <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 15px; color: #555555; margin: 0; line-height: 1.6;">{{INTRO}}</p>
+                        </td>
                     </tr>
 
                     <!-- TABLE OF CONTENTS -->
@@ -106,56 +79,22 @@
                         </td>
                     </tr>
 
-                    <!-- FOOTER DIVIDER -->
+                    <!-- FOOTER -->
                     <tr>
                         <td style="padding: 0 35px;">
                             <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
                                 <tr>
-                                    <td style="height: 1px; background-color: #E63946;"></td>
+                                    <td style="height: 1px; background-color: #E0E0E0;"></td>
                                 </tr>
                             </table>
                         </td>
                     </tr>
-
-                    <!-- FOOTER -->
                     <tr>
-                        <td style="background-color: #1A1A1A; padding: 30px 35px; text-align: center;">
-                            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-                                <tr>
-                                    <td align="center" style="padding-bottom: 20px;">
-                                        <span style="font-family: 'Bebas Neue', Impact, sans-serif; font-size: 28px; color: #FFFFFF; letter-spacing: 3px;">NV</span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td align="center" style="padding-bottom: 15px;">
-                                        <a href="https://nextvoters.org" style="font-family: 'DM Sans', Arial, sans-serif; font-size: 12px; color: #E63946; text-decoration: none; font-weight: 500; letter-spacing: 1px;">NEXTVOTERS.ORG</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td align="center" style="padding-bottom: 20px;">
-                                        <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 11px; color: #888888; line-height: 1.6;">
-                                            Empowering local democracy, one vote at a time.
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td align="center">
-                                        <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 10px; color: #666666; margin: 0; line-height: 1.5;">
-                                            You're receiving this because you signed up for NV local updates.<br>
-                                            <a href="{{UNSUBSCRIBE_URL}}" style="color: #E63946; text-decoration: underline;">Unsubscribe</a> from this list.
-                                        </p>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
-                </table>
-
-                <!-- VIEW IN BROWSER -->
-                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="max-width: 600px;">
-                    <tr>
-                        <td align="center" style="padding: 20px 10px 10px 10px;">
-                            <a href="#" style="font-family: 'DM Sans', Arial, sans-serif; font-size: 11px; color: #888888; text-decoration: none;">View this email in your browser</a>
+                        <td style="padding: 20px 35px 30px 35px; text-align: center;">
+                            <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 11px; color: #999999; margin: 0; line-height: 1.6;">
+                                You're receiving this because you signed up for Next Voters local updates.<br>
+                                <a href="{{UNSUBSCRIBE_URL}}" style="color: #E63946; text-decoration: underline;">Unsubscribe</a> from this list.
+                            </p>
                         </td>
                     </tr>
                 </table>

--- a/utils/email/templates.py
+++ b/utils/email/templates.py
@@ -56,6 +56,8 @@ def render_template(
     topic_sections_html: str | None = None,
     social_share_urls: dict[str, str] | None = None,
     table_of_contents_html: str | None = None,
+    greeting: str = "Good morning, New Voters.",
+    intro: str = "",
 ) -> str:
     """Render the email template with HTML content and optional social share URLs.
 
@@ -66,11 +68,15 @@ def render_template(
                            If None, default URLs (without referral code) are used.
         table_of_contents_html: Optional HTML for the table of contents to replace
                                 {{TABLE_OF_CONTENTS}}. If None, the placeholder is removed.
+        greeting: Greeting text for the email header.
+        intro: Introductory text describing what the email covers.
 
     Returns:
         Complete HTML email body.
     """
     template = load_template()
+    template = template.replace("{{GREETING}}", greeting)
+    template = template.replace("{{INTRO}}", intro)
     template = template.replace("{{TABLE_OF_CONTENTS}}", table_of_contents_html or "")
     if topic_sections_html is not None:
         template = template.replace("{{TOPIC_SECTIONS}}", topic_sections_html)

--- a/utils/schemas/__init__.py
+++ b/utils/schemas/__init__.py
@@ -1,6 +1,7 @@
 """Data schemas for LangGraph states and Pydantic models."""
 
 from utils.schemas.pydantic import (
+    LegislationItem,
     ReflectionEntry,
     SourceAssessment,
     WriterOutput,
@@ -12,6 +13,7 @@ from utils.schemas.state import (
 )
 
 __all__ = [
+    "LegislationItem",
     "ReflectionEntry",
     "SourceAssessment",
     "WriterOutput",

--- a/utils/schemas/pydantic.py
+++ b/utils/schemas/pydantic.py
@@ -49,16 +49,21 @@ class SourceAssessment(BaseModel):
     )
 
 
-class WriterOutput(BaseModel):
-    """Structured reflection output produced by the reflection tool."""
+class LegislationItem(BaseModel):
+    """A single legislation action with headline and description."""
 
-    title: Optional[str] = Field(
-        default=None, description="Title of the written content"
+    header: str = Field(
+        description="Short factual headline, e.g. 'Council passes good cause eviction package'"
     )
-    body: Optional[str] = Field(
-        default=None,
-        description="Main written content. They should be in bullet-point format.",
+    description: str = Field(
+        description="2-3 sentence plain-language description of what happened"
     )
-    summary: Optional[str] = Field(
-        default=None, description="Brief summary of the content"
+
+
+class WriterOutput(BaseModel):
+    """Structured output: list of legislation items discovered for a topic."""
+
+    items: list[LegislationItem] = Field(
+        default_factory=list,
+        description="List of legislation items found for this topic",
     )


### PR DESCRIPTION
## Summary
- Replace flat `WriterOutput` schema (title/body/summary) with structured `LegislationItem(header, description)` list for topic-organized reports
- Redesign email template to clean, minimal white-background newsletter with greeting, city-specific intro, and ALL CAPS topic sections
- Update email dispatcher subject line to `"Your {city} brief — city, state, and Congress this week"` and prepend `"Good morning, New Voters."` greeting

## Test plan
- [x] `python -m compileall -q .` passes
- [ ] Run `python main.py "New York City"` to verify new markdown output format
- [ ] Visually inspect email template rendering
- [ ] Run `python -m pytest evals/ -v` to verify updated test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)