### PR TITLE
Fix: widen Tavily search window and lower score threshold

### DIFF
--- a/utils/tools/utils/tavily.py
+++ b/utils/tools/utils/tavily.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 load_dotenv()
 from tavily import TavilyClient
 
-_MIN_SCORE = 0.30
+_MIN_SCORE = 0.15
 _MAX_RESULTS_CAP = 20
 
 _EXCLUDE_DOMAINS = [
@@ -110,7 +110,7 @@ def search_legislation(
         "max_results": fetch_count,
         "search_depth": "advanced",
         "topic": "general",
-        "time_range": "week",
+        "time_range": "month",
         "include_answer": False,
         "include_images": False,
         "include_raw_content": False,


### PR DESCRIPTION
## Summary
- Widen `time_range` from `"week"` to `"month"` — the 7-day window returned 0 results for all cities
- Lower `_MIN_SCORE` from 0.30 to 0.15 — valid government pages were being filtered out by Tavily's relevance scorer

## Test plan
- [x] `python -m compileall -q .` passes
- [ ] Re-run Azure container job and verify legislation sources are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)