### PR TITLE
Redesign email template as minimal text-first newsletter

### DIFF
--- a/pipelines/node/email_dispatcher.py
+++ b/pipelines/node/email_dispatcher.py
@@ -27,9 +27,8 @@ from utils.report.translator import LANG_MAP
 from utils.email.smtp import SMTPConnectionPool, send_single_email, is_email_configured
 from utils.email.templates import convert_markdown_to_html, render_template
 from utils.email.components import (
-    build_social_share_urls,
     build_all_topic_sections_html,
-    build_table_of_contents_html,
+    build_intro_html,
 )
 from pipelines.node.email_subscriber_content import (
     build_subscriber_topic_reports,
@@ -198,23 +197,11 @@ def dispatch_emails_to_subscribers(
 
         # Convert to HTML topic sections and queue for sending
         topic_html_pairs = [(name, convert_markdown_to_html(md)) for name, md in topic_reports]
-        topic_names = [name for name, _ in topic_reports]
         sections_html = build_all_topic_sections_html(topic_html_pairs, referral_code=referral_code, city=city)
-        social_share_urls = build_social_share_urls(referral_code=referral_code)
-        toc_html = build_table_of_contents_html(topic_names)
-
-        intro = (
-            f"Here\u2019s what {city}, the statehouse, and Washington actually did this "
-            f"week \u2014 organized by topic, every claim cited."
-        )
-
+        intro_html = build_intro_html(city=city)
         html_body = render_template(
-            "",
             topic_sections_html=sections_html,
-            social_share_urls=social_share_urls,
-            table_of_contents_html=toc_html,
-            greeting="Good morning, New Voters.",
-            intro=intro,
+            intro_html=intro_html,
         )
 
         send_queue.append({
@@ -265,7 +252,7 @@ def dispatch_emails_to_subscribers(
                         send_single_email,
                         pool,
                         item["contact"],
-                        f"Your {item['city']} brief \u2014 city, state, and Congress this week",
+                        f"NV Local Report - {item['city']}",
                         item["html_body"],
                         failures_queue,
                     )

--- a/pipelines/node/email_sender.py
+++ b/pipelines/node/email_sender.py
@@ -105,7 +105,13 @@ def send_email_to_subscribers(inputs: ChainData) -> ChainData:
     logger.info(f"Sending report email to {len(emails)} subscriber(s)")
 
     html_content = convert_markdown_to_html(markdown_report)
-    html_body = render_template(html_content)
+    section = (
+        '<tr><td style="padding-top: 16px; font-family: -apple-system, '
+        "BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; "
+        'font-size: 15px; color: #1A1A1A; line-height: 1.6;">'
+        f"{html_content}</td></tr>"
+    )
+    html_body = render_template(section)
 
     try:
         pool = SMTPConnectionPool(pool_size=10)

--- a/templates/email_report.html
+++ b/templates/email_report.html
@@ -4,97 +4,38 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Next Voters Brief</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,700&display=swap" rel="stylesheet">
     <!--[if mso]>
     <style type="text/css">
-        body, table, td {font-family: 'DM Sans', Arial, sans-serif !important;}
+        body, table, td, p, span {font-family: Arial, Helvetica, sans-serif !important;}
     </style>
     <![endif]-->
 </head>
-<body style="margin: 0; padding: 0; background-color: #F5F5F0;">
-    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#F5F5F0">
+<body style="margin: 0; padding: 0; background-color: #FFFFFF; color: #1A1A1A;">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#FFFFFF">
         <tr>
-            <td align="center" style="padding: 20px 10px;">
-                <!-- MAIN CONTAINER -->
-                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="max-width: 600px; background-color: #FFFFFF; border-collapse: collapse;">
-                    <!-- HEADER -->
+            <td align="center" style="padding: 24px 16px;">
+                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="max-width: 640px;">
+                    <!-- INTRO -->
                     <tr>
-                        <td style="padding: 30px 35px 10px 35px;">
-                            <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; color: #E63946; font-weight: 700; letter-spacing: 1px;">NEXT VOTERS</span>
+                        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; color: #1A1A1A; line-height: 1.55; padding-bottom: 8px;">
+                            {{INTRO_HTML}}
                         </td>
                     </tr>
 
-                    <!-- GREETING & INTRO -->
-                    <tr>
-                        <td style="padding: 10px 35px 5px 35px;">
-                            <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 15px; color: #1A1A1A; margin: 0 0 10px 0; line-height: 1.6;">{{GREETING}}</p>
-                            <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 15px; color: #555555; margin: 0; line-height: 1.6;">{{INTRO}}</p>
-                        </td>
-                    </tr>
-
-                    <!-- TABLE OF CONTENTS -->
-                    {{TABLE_OF_CONTENTS}}
-
-                    <!-- CONTENT AREA -->
+                    <!-- TOPIC SECTIONS -->
                     {{TOPIC_SECTIONS}}
-                    <!-- {{CONTENT}} -->
-
-                    <!-- SOCIAL SHARE SECTION -->
-                    <tr>
-                        <td style="background-color: #F8F8F5; padding: 25px 35px;">
-                            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-                                <tr>
-                                    <td align="center" style="padding-bottom: 15px;">
-                                        <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; color: #1A1A1A; text-transform: uppercase; font-weight: 700; letter-spacing: 1px;">Share This Report</span>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td align="center" style="padding-bottom: 12px;">
-                                        <table role="presentation" border="0" cellspacing="0" cellpadding="0">
-                                            <tr>
-                                                <!-- Twitter/X Button -->
-                                                <td align="center" style="padding: 0 6px;">
-                                                    <a href="{{TWITTER_SHARE_URL}}" target="_blank" style="display: inline-block; width: 40px; height: 40px; line-height: 40px; background-color: #1A1A1A; border-radius: 8px; text-align: center; text-decoration: none; font-family: 'DM Sans', Arial, sans-serif; font-size: 16px; font-weight: 700; color: #FFFFFF;">X</a>
-                                                </td>
-                                                <!-- Facebook Button -->
-                                                <td align="center" style="padding: 0 6px;">
-                                                    <a href="{{FACEBOOK_SHARE_URL}}" target="_blank" style="display: inline-block; width: 40px; height: 40px; line-height: 40px; background-color: #1877F2; border-radius: 8px; text-align: center; text-decoration: none; font-family: 'DM Sans', Arial, sans-serif; font-size: 16px; font-weight: 700; color: #FFFFFF;">f</a>
-                                                </td>
-                                                <!-- LinkedIn Button -->
-                                                <td align="center" style="padding: 0 6px;">
-                                                    <a href="{{LINKEDIN_SHARE_URL}}" target="_blank" style="display: inline-block; width: 40px; height: 40px; line-height: 40px; background-color: #0A66C2; border-radius: 8px; text-align: center; text-decoration: none; font-family: 'DM Sans', Arial, sans-serif; font-size: 16px; font-weight: 700; color: #FFFFFF;">in</a>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td align="center">
-                                        <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 12px; color: #666666; line-height: 1.5;">Help your community stay informed</span>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
 
                     <!-- FOOTER -->
                     <tr>
-                        <td style="padding: 0 35px;">
+                        <td style="padding-top: 32px;">
                             <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
                                 <tr>
-                                    <td style="height: 1px; background-color: #E0E0E0;"></td>
+                                    <td style="border-top: 1px solid #E5E5E5; padding-top: 16px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #888888; line-height: 1.5;">
+                                        You're receiving this because you signed up for Next Voters local updates.
+                                        <a href="{{UNSUBSCRIBE_URL}}" style="color: #888888; text-decoration: underline;">Unsubscribe</a>.
+                                    </td>
                                 </tr>
                             </table>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td style="padding: 20px 35px 30px 35px; text-align: center;">
-                            <p style="font-family: 'DM Sans', Arial, sans-serif; font-size: 11px; color: #999999; margin: 0; line-height: 1.6;">
-                                You're receiving this because you signed up for Next Voters local updates.<br>
-                                <a href="{{UNSUBSCRIBE_URL}}" style="color: #E63946; text-decoration: underline;">Unsubscribe</a> from this list.
-                            </p>
                         </td>
                     </tr>
                 </table>

--- a/utils/email/components.py
+++ b/utils/email/components.py
@@ -1,9 +1,10 @@
 """
-HTML component builders for branded emails.
+HTML component builders for minimal text-first emails.
 
-These functions assemble discrete pieces of email HTML — topic sections,
-table of contents, per-topic share rows, and social share URLs — which the
-top-level template renderer weaves into the final email body.
+These functions assemble the small set of HTML pieces the new template
+expects: the intro greeting block and the topic sections. The previous
+branded components (TOC, social share, accent borders) have been removed
+to match the text-first design.
 """
 
 from urllib.parse import quote
@@ -11,6 +12,10 @@ from urllib.parse import quote
 
 BASE_SHARE_URL = "https://nextvoters.com/request-region"
 SHARE_TEXT = "Stay informed about your local politics with free weekly reports from Next Voters"
+
+SANS_STACK = (
+    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+)
 
 
 def build_social_share_urls(
@@ -20,25 +25,18 @@ def build_social_share_urls(
 ) -> dict[str, str]:
     """Build social share URLs for Twitter/X, Facebook, and LinkedIn.
 
-    Constructs platform-specific sharing URLs pointing to the Next Voters
-    sign-up page. If a referral code is provided, it is appended as a
-    query parameter. If city and topic are provided, contextual share text
-    is used instead of the default.
-
-    Args:
-        referral_code: Optional referral code to append as ?ref=CODE
-        city: Optional city name for contextual share text
-        topic: Optional topic name for contextual share text
-
-    Returns:
-        Dictionary with keys 'twitter', 'facebook', 'linkedin' mapping to share URLs.
+    Retained because callers still construct these for tracking, even though
+    the minimal template no longer renders share buttons.
     """
     page_url = BASE_SHARE_URL
     if referral_code:
         page_url = f"{BASE_SHARE_URL}?ref={quote(referral_code, safe='')}"
 
     if city and topic:
-        share_text = f"Check out what's happening in {city} on {topic} — stay informed with Next Voters"
+        share_text = (
+            f"Check out what's happening in {city} on {topic} — "
+            f"stay informed with Next Voters"
+        )
     else:
         share_text = SHARE_TEXT
 
@@ -52,128 +50,44 @@ def build_social_share_urls(
     }
 
 
-TOPIC_COLOR_MAP: dict[str, str] = {
-    "Immigration": "#2563EB",
-    "Civil Rights": "#7C3AED",
-    "Economy": "#059669",
-}
-DEFAULT_TOPIC_COLOR = "#E63946"
+def build_intro_html(city: str | None = None) -> str:
+    """Build the greeting + framing paragraph that opens the email.
 
-
-def get_topic_color(topic_name: str) -> str:
-    """Look up the accent color for a topic, falling back to the default red.
-
-    Args:
-        topic_name: The topic name to look up (case-insensitive match).
-
-    Returns:
-        Hex color string for the topic.
+    Matches the text-first style: a one-line greeting addressed to the city's
+    residents, followed by a single framing sentence about what's in the brief.
     """
-    for key, color in TOPIC_COLOR_MAP.items():
-        if key.lower() == topic_name.lower():
-            return color
-    return DEFAULT_TOPIC_COLOR
+    city_label = (city or "").strip() or "your community"
+    residents = f"{city_label} residents" if city_label != "your community" else city_label
+    return (
+        f'<p style="font-family: {SANS_STACK}; font-size: 15px; color: #1A1A1A; '
+        f'line-height: 1.55; margin: 0 0 12px 0;">Good morning, {residents}.</p>'
+        f'<p style="font-family: {SANS_STACK}; font-size: 15px; color: #1A1A1A; '
+        f'line-height: 1.55; margin: 0 0 24px 0;">'
+        f"Here's what {city_label} actually did this week — organized by topic, "
+        f"every claim cited.</p>"
+    )
 
 
-def build_topic_share_row_html(twitter_url: str, facebook_url: str, linkedin_url: str) -> str:
-    """Return a compact inline share row for use inside topic sections.
+def build_topic_section_html(topic_name: str, html_content: str) -> str:
+    """Build a single topic section: small-caps label + content.
 
-    Renders smaller 32x32 share buttons with a 'Share this topic' micro-label,
-    suitable for embedding after each topic's content.
-
-    Args:
-        twitter_url: Twitter/X share URL
-        facebook_url: Facebook share URL
-        linkedin_url: LinkedIn share URL
-
-    Returns:
-        HTML string for the inline share row.
-    """
-    return f"""
-      <tr>
-        <td style="padding: 10px 0 5px 0;">
-          <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-            <tr>
-              <td align="center" style="padding-bottom: 6px;">
-                <span style="font-family: 'DM Sans', Arial, sans-serif; font-size: 11px; color: #888888; text-transform: uppercase; letter-spacing: 1px;">Share this topic</span>
-              </td>
-            </tr>
-            <tr>
-              <td align="center">
-                <table role="presentation" border="0" cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td align="center" style="padding: 0 4px;">
-                      <a href="{twitter_url}" target="_blank" style="display: inline-block; width: 32px; height: 32px; line-height: 32px; background-color: #1A1A1A; border-radius: 6px; text-align: center; text-decoration: none; font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; font-weight: 700; color: #FFFFFF;">X</a>
-                    </td>
-                    <td align="center" style="padding: 0 4px;">
-                      <a href="{facebook_url}" target="_blank" style="display: inline-block; width: 32px; height: 32px; line-height: 32px; background-color: #1877F2; border-radius: 6px; text-align: center; text-decoration: none; font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; font-weight: 700; color: #FFFFFF;">f</a>
-                    </td>
-                    <td align="center" style="padding: 0 4px;">
-                      <a href="{linkedin_url}" target="_blank" style="display: inline-block; width: 32px; height: 32px; line-height: 32px; background-color: #0A66C2; border-radius: 6px; text-align: center; text-decoration: none; font-family: 'DM Sans', Arial, sans-serif; font-size: 13px; font-weight: 700; color: #FFFFFF;">in</a>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>"""
-
-
-def build_topic_section_html(
-    topic_name: str,
-    html_content: str,
-    topic_color: str = DEFAULT_TOPIC_COLOR,
-    share_row_html: str = "",
-) -> str:
-    """Build HTML for a single topic section with header, content, and optional share row.
-
-    Args:
-        topic_name: Display name for the topic header.
-        html_content: Rendered HTML body for the topic.
-        topic_color: Hex color for the left accent border (default: #E63946).
-        share_row_html: Optional inline share row HTML to append after content.
-
-    Returns:
-        HTML string for the complete topic section.
+    The label is rendered in tracked-out uppercase with a thin gray rule above,
+    matching the minimal newsletter style. The content (already HTML-converted
+    markdown) sits underneath in plain prose.
     """
     return f"""
     <tr>
-      <td style="padding: 0 35px;">
+      <td style="padding-top: 24px;">
         <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
           <tr>
-            <td style="padding-top: 25px; padding-bottom: 8px;">
-              <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-                <tr>
-                  <td style="background-color: #F8F8F5; border-left: 4px solid {topic_color}; padding: 12px 20px;">
-                    <span style="font-family: 'Bebas Neue', Impact, sans-serif; font-size: 22px; color: #1A1A1A; letter-spacing: 2px; text-transform: uppercase;">{topic_name}</span>
-                  </td>
-                </tr>
-              </table>
+            <td style="border-top: 1px solid #D9D9D9; padding-top: 14px;">
+              <span style="font-family: {SANS_STACK}; font-size: 12px; color: #555555; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 700;">{topic_name.upper()}</span>
             </td>
           </tr>
           <tr>
-            <td style="padding: 15px 0 25px 0; font-family: 'DM Sans', Arial, sans-serif; font-size: 14px; color: #333333; line-height: 1.7;">
+            <td style="padding-top: 6px; font-family: {SANS_STACK}; font-size: 15px; color: #1A1A1A; line-height: 1.6;">
               {html_content}
             </td>
-          </tr>
-          {share_row_html}
-        </table>
-      </td>
-    </tr>"""
-
-
-def build_topic_divider_html() -> str:
-    """Build HTML divider between topic sections.
-
-    Uses a 2px gradient-style divider for stronger visual separation.
-    """
-    return """
-    <tr>
-      <td style="padding: 0 35px;">
-        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-          <tr>
-            <td style="height: 2px; background: linear-gradient(to right, #E63946, #E8E8E4, #E63946);"></td>
           </tr>
         </table>
       </td>
@@ -185,70 +99,16 @@ def build_all_topic_sections_html(
     referral_code: str | None = None,
     city: str | None = None,
 ) -> str:
-    """Build combined HTML for all topic sections with dividers between them.
-
-    For each topic, looks up its accent color and generates per-topic share
-    URLs (with optional referral code and city context). A compact share row
-    is appended after each topic's content.
+    """Build combined HTML for all topic sections.
 
     Args:
         topics: List of (topic_name, html_content) tuples.
-        referral_code: Optional referral code for share URLs.
-        city: Optional city name for contextual share text.
+        referral_code: Unused; retained for API compatibility with callers.
+        city: Unused; retained for API compatibility with callers.
 
     Returns:
         Combined HTML string for all topic sections.
     """
     if not topics:
         return ""
-    sections = []
-    for i, (name, content) in enumerate(topics):
-        color = get_topic_color(name)
-        sections.append(build_topic_section_html(name, content, topic_color=color))
-        if i < len(topics) - 1:
-            sections.append(build_topic_divider_html())
-    return "\n".join(sections)
-
-
-def build_table_of_contents_html(topic_names: list[str]) -> str:
-    """Build an HTML table-of-contents section listing topic names.
-
-    Each topic is rendered as a list item with a colored accent dot matching
-    its topic color from TOPIC_COLOR_MAP.
-
-    Args:
-        topic_names: List of topic names to include in the TOC.
-
-    Returns:
-        HTML string for the TOC section, or empty string if no topics.
-    """
-    if not topic_names:
-        return ""
-
-    items = []
-    for name in topic_names:
-        color = get_topic_color(name)
-        items.append(
-            f'<li style="font-family: \'DM Sans\', Arial, sans-serif; font-size: 14px; '
-            f'color: #333333; padding: 4px 0; list-style: none;">'
-            f'<span style="display: inline-block; width: 8px; height: 8px; '
-            f'border-radius: 50%; background-color: {color}; margin-right: 10px; '
-            f'vertical-align: middle;"></span>{name}</li>'
-        )
-
-    items_html = "\n".join(items)
-    return f"""
-    <tr>
-      <td style="padding: 20px 35px 0 35px;">
-        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
-          <tr>
-            <td style="background-color: #F5F5F0; border-radius: 8px; padding: 18px 24px;">
-              <span style="font-family: 'Bebas Neue', Impact, sans-serif; font-size: 16px; color: #1A1A1A; letter-spacing: 2px; text-transform: uppercase; display: block; padding-bottom: 8px;">In This Report</span>
-              <ul style="margin: 0; padding: 0;">
-                {items_html}
-              </ul>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>"""
+    return "\n".join(build_topic_section_html(name, content) for name, content in topics)

--- a/utils/email/templates.py
+++ b/utils/email/templates.py
@@ -1,9 +1,8 @@
 """
 Email template rendering.
 
-Loads the branded HTML template from disk, converts markdown report bodies
-to HTML, and fills the template placeholders (topic sections, TOC, social
-share URLs, main content).
+Loads the minimal HTML template from disk, converts markdown report bodies
+to HTML, and fills the template placeholders (intro, topic sections).
 """
 
 import os
@@ -11,8 +10,6 @@ import logging
 from functools import lru_cache
 
 import markdown
-
-from utils.email.components import build_social_share_urls
 
 logger = logging.getLogger(__name__)
 
@@ -40,53 +37,27 @@ def load_template() -> str:
 
 
 def convert_markdown_to_html(markdown_content: str) -> str:
-    """Convert markdown content to HTML.
-
-    Args:
-        markdown_content: Markdown text to convert
-
-    Returns:
-        HTML representation of the markdown
-    """
+    """Convert markdown content to HTML."""
     return markdown.markdown(markdown_content)
 
 
 def render_template(
-    html_content: str,
-    topic_sections_html: str | None = None,
-    social_share_urls: dict[str, str] | None = None,
-    table_of_contents_html: str | None = None,
-    greeting: str = "Good morning, New Voters.",
-    intro: str = "",
+    topic_sections_html: str,
+    intro_html: str = "",
+    unsubscribe_url: str = "#",
 ) -> str:
-    """Render the email template with HTML content and optional social share URLs.
+    """Render the minimal email template.
 
     Args:
-        html_content: HTML content to insert into template
-        topic_sections_html: Optional HTML for topic sections to replace {{TOPIC_SECTIONS}}.
-        social_share_urls: Optional dict with 'twitter', 'facebook', 'linkedin' share URLs.
-                           If None, default URLs (without referral code) are used.
-        table_of_contents_html: Optional HTML for the table of contents to replace
-                                {{TABLE_OF_CONTENTS}}. If None, the placeholder is removed.
-        greeting: Greeting text for the email header.
-        intro: Introductory text describing what the email covers.
+        topic_sections_html: HTML for the topic sections, replaces {{TOPIC_SECTIONS}}.
+        intro_html: HTML for the greeting + framing paragraphs at the top.
+        unsubscribe_url: URL for the footer unsubscribe link.
 
     Returns:
         Complete HTML email body.
     """
     template = load_template()
-    template = template.replace("{{GREETING}}", greeting)
-    template = template.replace("{{INTRO}}", intro)
-    template = template.replace("{{TABLE_OF_CONTENTS}}", table_of_contents_html or "")
-    if topic_sections_html is not None:
-        template = template.replace("{{TOPIC_SECTIONS}}", topic_sections_html)
-    rendered = template.replace("{{CONTENT}}", html_content)
-
-    if social_share_urls is None:
-        social_share_urls = build_social_share_urls()
-
-    rendered = rendered.replace("{{TWITTER_SHARE_URL}}", social_share_urls["twitter"])
-    rendered = rendered.replace("{{FACEBOOK_SHARE_URL}}", social_share_urls["facebook"])
-    rendered = rendered.replace("{{LINKEDIN_SHARE_URL}}", social_share_urls["linkedin"])
-
-    return rendered
+    template = template.replace("{{INTRO_HTML}}", intro_html)
+    template = template.replace("{{TOPIC_SECTIONS}}", topic_sections_html)
+    template = template.replace("{{UNSUBSCRIBE_URL}}", unsubscribe_url)
+    return template

--- a/utils/report/storage.py
+++ b/utils/report/storage.py
@@ -21,8 +21,15 @@ def _slugify(text: str) -> str:
 
 
 def _render(md: str) -> str:
-    """Convert markdown to full branded HTML."""
-    return render_template(convert_markdown_to_html(md))
+    """Convert markdown to a full HTML page using the email template."""
+    body = convert_markdown_to_html(md)
+    section = (
+        '<tr><td style="padding-top: 16px; font-family: -apple-system, '
+        "BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; "
+        'font-size: 15px; color: #1A1A1A; line-height: 1.6;">'
+        f"{body}</td></tr>"
+    )
+    return render_template(section)
 
 
 def upload_report(city: str, topic: str, html: str, lang: str = "en") -> str | None:


### PR DESCRIPTION
## Summary
- Replaces the branded NV header, dark banner, social-share section, TOC, and dark footer with a minimal text-first layout: greeting + framing paragraph, small-caps topic labels with a thin rule above, prose body, and a tiny unsubscribe footer
- Trims `utils/email/components.py` to just the pieces the new template uses (`build_intro_html`, `build_topic_section_html`, `build_all_topic_sections_html`); `build_social_share_urls` retained for callers, but share buttons are no longer rendered
- Simplifies `render_template` to `(topic_sections_html, intro_html, unsubscribe_url)` and updates the dispatcher / storage / legacy email_sender callers accordingly

## Test plan
- [ ] `python -m compileall -q .` passes
- [ ] Programmatic render of a sample report produces the expected minimal HTML (verified locally via `/tmp/preview.html`)
- [ ] End-to-end pipeline run with SMTP configured delivers an email matching the screenshot's style

🤖 Generated with [Claude Code](https://claude.com/claude-code)