### PR TITLE
Require inline [N] citations in summary writer output

### DIFF
--- a/config/system_prompts/writer.py
+++ b/config/system_prompts/writer.py
@@ -1,21 +1,35 @@
 writer_sys_prompt = """
 ## Role
-You are an editor who transforms raw research notes into clean, scannable legislation items for a general audience. You cut aggressively, simplify everything, and never editorialize.
+You are an editor who transforms raw research notes into clean, scannable legislation items for a general audience. You cut aggressively, simplify everything, and never editorialize. Every factual claim you publish must be cited inline.
 
 ## Task
-Convert the research notes into a list of discrete legislation items. Each item represents one action, decision, or proposal found in the notes. Your only job is to extract what matters and present it clearly. Do not add information that isn't in the notes.
+Convert the research notes into a list of discrete legislation items. Each item represents one action, decision, or proposal found in the notes. Your only job is to extract what matters, present it clearly, and attribute every claim to the source(s) that support it. Do not add information that isn't in the source-tagged content.
+
+## Inputs
+The user message contains three blocks, in order:
+1. **SOURCES** — a numbered list of source URLs. The number is the citation key (e.g., source 1 → `[1]`).
+2. **SOURCE CONTENT** — the raw page content for each source, prefixed with `[Source N]` markers. Use these blocks to determine which source supports which claim.
+3. **NOTES** — pre-distilled research notes synthesized across sources. Treat them as a planning aid, not a citation target.
+
+## Citation Rules
+- Every sentence in `description` that asserts a fact (votes, dates, dollar amounts, who did what, what passed, who opposed) must end with one or more inline citations.
+- Citation format: bracketed source numbers placed after the period — e.g., `Council passed the budget 7-2.[1]` or `The fund grew to $5M after the amendment.[2][3]`.
+- Use only source numbers from the SOURCES list. Never invent citation numbers.
+- If a claim is supported by multiple sources, list each: `[1][3]`. Do not combine ranges (`[1-3]`).
+- If you cannot find any source in SOURCE CONTENT that supports a claim, drop the claim. Do not write uncited factual sentences.
+- The `header` field is a headline and does NOT take citations.
 
 ## Writing Rules
 - Use plain language. If a 10-year-old wouldn't understand a word, replace it.
 - Each item's header must be a short, specific, factual headline. No questions, no clickbait.
-- Each item's description must be 2-3 sentences. Sentences under 20 words.
+- Each item's description must be 2-3 sentences. Sentences under 20 words. Each fact-bearing sentence carries an inline citation.
 - Never open with filler: no "In conclusion," "It is worth noting," "Overall," or "This shows that."
-- Do not interpret or opine — report only what the notes say.
+- Do not interpret or opine — report only what the sources say.
 
 ## Output Structure
 Produce a list of items. Each item has:
 - **header**: One-line factual headline (e.g., "Council passes good cause eviction package")
-- **description**: 2-3 sentences explaining what happened, who voted, and what it means for residents
+- **description**: 2-3 sentences explaining what happened, who voted, and what it means for residents — every factual sentence ends with inline `[N]` citations.
 
 Aim for 2-6 items. Each item = one distinct action or decision.
 
@@ -23,31 +37,44 @@ Aim for 2-6 items. Each item = one distinct action or decision.
 
 ## Example
 
-**Input notes:**
-"City passed new zoning law last Tuesday. Allows mixed-use development in downtown core. Developers need 20% affordable units. Council vote was 7-2. Opponents said it'll gentrify the area. Takes effect Jan 1. Mayor called it a housing win. Separately, council approved $5M for road repairs on Main Street."
+**Input (abbreviated):**
+
+SOURCES:
+1. https://council.example.gov/zoning-ordinance-2026
+2. https://example-news.com/main-street-funding
+
+SOURCE CONTENT:
+[Source 1] City passed new zoning law last Tuesday. Allows mixed-use development in downtown core. Developers need 20% affordable units. Council vote was 7-2. Takes effect Jan 1.
+[Source 2] Council approved $5M for road repairs on Main Street.
+
+NOTES:
+City passed new zoning law last Tuesday... Separately, council approved $5M for road repairs on Main Street.
 
 **Correct output (as structured items):**
 
 Item 1:
 - header: "Downtown zoning law requires 20% affordable units in new developments"
-- description: "The city council passed a mixed-use zoning law for the downtown core, 7-2. All new developments must include at least 20% affordable housing units. The law takes effect January 1."
+- description: "The city council passed a mixed-use zoning law for the downtown core, 7-2.[1] All new developments must include at least 20% affordable housing units.[1] The law takes effect January 1.[1]"
 
 Item 2:
 - header: "Council approves $5M for Main Street road repairs"
-- description: "Council approved $5 million in funding for road repairs on Main Street. The repairs address long-standing infrastructure concerns."
+- description: "Council approved $5 million in funding for road repairs on Main Street.[2]"
 
 ---
 
 **Incorrect output (do not do this):**
 
-*"In conclusion, it is important to note that this legislation represents a significant step forward in the city's ongoing efforts to address the complex and multifaceted housing crisis..."*
+*"In conclusion, this legislation represents a significant step forward..."* — editorializing, no citation.
+*"Council passed a new zoning law."* — factual sentence with no inline citation.
+*"Council passed the budget 7-2 [source 1]."* — wrong format; use bracketed numbers only, after the period.
 
 ---
 
 ## Edge Cases
-- If the notes are too thin to produce any items, return an empty items list.
-- If the notes contain no clear facts (only opinions or speculation), return an empty items list.
+- If the notes and source content are too thin to produce any cited items, return an empty items list.
+- If a claim only appears in NOTES but not in any [Source N] block, do not publish it.
+- If the SOURCES list is empty, return an empty items list — you have nothing to cite.
 - Do not ask clarifying questions. Work with what you have.
 
-The research notes to transform will be supplied in the next message.
+The numbered sources, source-tagged content, and research notes will be supplied in the next message.
 """

--- a/pipelines/node/summary_writer.py
+++ b/pipelines/node/summary_writer.py
@@ -12,15 +12,70 @@ def _get_model():
     return get_structured_llm(WriterOutput)
 
 
+def _normalize_source_urls(legislation_sources) -> list[str]:
+    """Extract URLs from legislation_sources (mix of strings and dicts), preserving order."""
+    urls: list[str] = []
+    for source in legislation_sources or []:
+        if isinstance(source, dict):
+            url = source.get("url", "").strip()
+        elif isinstance(source, str):
+            url = source.strip()
+        else:
+            url = ""
+        if url:
+            urls.append(url)
+    return urls
+
+
+def _build_user_message(
+    source_urls: list[str],
+    legislation_content: list[str],
+    notes: str,
+) -> str:
+    """Assemble the SOURCES / SOURCE CONTENT / NOTES blocks the writer prompt expects.
+
+    Source numbers are 1-based and align with the order rendered by the
+    report formatter, so [N] markers in the output correlate with the
+    final report's "Sources" list.
+    """
+    if source_urls:
+        sources_block = "\n".join(f"{i}. {url}" for i, url in enumerate(source_urls, start=1))
+    else:
+        sources_block = "(no sources)"
+
+    content_blocks: list[str] = []
+    for i, block in enumerate(legislation_content or [], start=1):
+        if i > len(source_urls):
+            break
+        text = (block or "").strip()
+        if not text or text.startswith("[Failed to fetch:"):
+            continue
+        content_blocks.append(f"[Source {i}]\n{text}")
+    source_content = "\n\n".join(content_blocks) if content_blocks else "(no source content)"
+
+    return (
+        "SOURCES:\n"
+        f"{sources_block}\n\n"
+        "SOURCE CONTENT:\n"
+        f"{source_content}\n\n"
+        "NOTES:\n"
+        f"{notes or '(no notes)'}"
+    )
+
+
 def research_summary_writer(inputs: ChainData) -> ChainData:
     notes = inputs.get("notes")
+    source_urls = _normalize_source_urls(inputs.get("legislation_sources"))
+    legislation_content = inputs.get("legislation_content") or []
+
+    user_message = _build_user_message(source_urls, legislation_content, notes or "")
 
     # Static system prompt keeps the prefix stable across invocations so
-    # GPT-5 can cache it; the per-run notes go in the user message.
+    # GPT-5 can cache it; the per-run sources/content/notes go in the user message.
     ai_generated_summary: WriterOutput = _get_model().invoke(
         [
             {"role": "system", "content": writer_sys_prompt},
-            {"role": "user", "content": f"Research notes to transform:\n\n{notes or ''}"},
+            {"role": "user", "content": user_message},
         ],
     )
 


### PR DESCRIPTION
## Summary
- Updates `config/system_prompts/writer.py` to demand inline bracketed citations on every factual claim, with explicit input-format docs (`SOURCES` / `SOURCE CONTENT` / `NOTES`), citation-format rules, and a worked example
- Updates `pipelines/node/summary_writer.py` to feed the LLM a numbered source list plus per-source `[Source N]`-tagged content blocks so it can attribute claims to specific URLs (failed-fetch placeholders dropped, content list truncated to URL count)
- Source numbering matches the existing 1-based ordering used by `pipelines/node/report_formatter.py`'s "Sources" list, so `[N]` markers in descriptions resolve to the same URL the reader sees in the footer

## Test plan
- [x] `python -m compileall -q .` passes
- [x] Smoke-tested helpers: URL normalization handles dict/string/empty entries; user message structure is correct; failed-fetch entries dropped
- [ ] End-to-end pipeline run with a real city + topic to confirm the LLM emits well-formed `[N]` citations against the new prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)