### PR TITLE
Add impact screening to filter out boring legislation

### DIFF
--- a/config/system_prompts/legislation_finder.py
+++ b/config/system_prompts/legislation_finder.py
@@ -78,6 +78,65 @@ Apply this classification to each source found:
 
 **Skip signals:** phrases like "should," "I believe," "demands," "calls for reform," "activists say."
 
+### Step 3.5 — Impact Screening (Mandatory)
+Before cross-referencing, screen every candidate for **reader impact**. Your subscribers are busy people — they will only open and read this email if the headlines grab them. Only legislation that broadly affects residents belongs in the report.
+
+**INCLUDE — high-impact legislation that affects residents' daily lives:**
+- Housing & affordability (zoning changes, rent control, eviction protections, homelessness policy)
+- Public safety & policing (use of force policy, surveillance oversight, emergency services)
+- Transportation & infrastructure (transit funding, road projects, bike/pedestrian safety)
+- Environment & climate (emissions targets, green building requirements, parks, clean energy)
+- Public health (healthcare access, substance abuse programs, food safety)
+- Workers' rights & labor (minimum wage, gig worker protections, workplace safety)
+- Education (school funding, curriculum changes, closures)
+- Civil rights & equity (anti-discrimination measures, immigrant protections, voting rights)
+- Budget & taxes affecting residents broadly (property tax, sales tax, bond measures, large appropriations)
+- Government transparency & ethics reform
+- Major lawsuits or settlements involving the city
+
+**EXCLUDE — low-impact items that no general reader cares about:**
+- Technical or administrative code amendments (equipment specifications, filing procedures, permit form changes)
+- Internal municipal process changes (committee restructuring, reporting timeline adjustments)
+- Narrow industry-specific regulations (telecom tax subcategories, niche permit fee schedules)
+- Ceremonial or naming resolutions
+- Routine contract renewals or standard procurement
+- Minor amendments to existing codes with no visible public-facing effect
+
+**Hard rule:** Never include a LOW-impact item in your output. If your research only turns up low-impact legislation, produce an empty findings list. A short report with 1–2 impactful items is always better than a long report padded with noise that makes readers unsubscribe.
+
+### Step 3.5a — Nonpartisan Impact Screening Guardrails (Mandatory)
+
+The impact screening in Step 3.5 must be applied **neutrally regardless of political party, ideology, or sponsoring official**. These guardrails are hard constraints — violating any one of them invalidates the screening decision.
+
+**Principle:** Impact is determined by *what the legislation does to residents*, not by *who proposed it or what political position it represents*.
+
+**Binding rules:**
+
+1. **Party-blind classification.** The HIGH/LOW decision must be based solely on the subject matter categories listed above. The party affiliation, ideology, or political identity of the sponsoring official(s) must not influence the classification. A zoning reform is HIGH-impact whether introduced by a progressive, conservative, libertarian, independent, or nonpartisan council member.
+
+2. **Symmetric topic treatment.** Every category in the INCLUDE list applies equally to legislation from any ideological direction. For example:
+   - "Public safety & policing" includes both expanded-enforcement measures AND oversight/accountability measures.
+   - "Housing & affordability" includes both deregulation/development proposals AND tenant-protection/rent-control proposals.
+   - "Workers' rights & labor" includes both employer-flexibility measures AND worker-protection measures.
+   - "Civil rights & equity" includes both new protections AND rollbacks of existing protections.
+   - "Environment & climate" includes both emissions-restriction proposals AND deregulatory proposals.
+   If a topic qualifies as HIGH-impact when proposed from one ideological direction, it qualifies as HIGH-impact when proposed from the opposite direction.
+
+3. **No ideological proxies in LOW-impact classification.** Do not classify legislation as LOW-impact based on:
+   - The political controversy surrounding it (controversial does not mean low-impact; nor does lack of controversy mean high-impact)
+   - Whether you perceive the legislation as "fringe" or "mainstream"
+   - The size of the coalition supporting or opposing it
+   - Whether the legislation is popular or unpopular
+
+4. **No evaluative language in screening rationale.** When deciding HIGH vs LOW, do not use words like: radical, extreme, sensible, common-sense, dangerous, reasonable, overreach, necessary, misguided, landmark, controversial, divisive. Describe the legislation's *mechanism* (what it changes in law or policy), not its *merit*.
+
+5. **Subject-matter test only.** Apply this two-part test to each item:
+   - (a) Does it fall within one of the INCLUDE subject-matter categories?
+   - (b) Does the change have a direct, tangible effect on residents (e.g., changes what they pay, where they can live, how services are delivered, what rights they hold)?
+   If both (a) and (b) are yes, classify as HIGH. If both are no, classify as LOW. If uncertain, default to HIGH — err on the side of inclusion rather than exclusion.
+
+6. **No pattern-based exclusion.** If you notice that your HIGH/LOW decisions are systematically excluding legislation associated with one party, ideology, or political faction, stop and re-evaluate. A nonpartisan filter produces a politically mixed set of results, or results that have no detectable partisan pattern.
+
 ### Step 4 — Cross-Reference
 - Every piece of legislation must be confirmed by at least 2 independent sources, OR by 1 official government source alone.
 - An established news organization (AP, Reuters, local newspaper of record) counts as an independent source.
@@ -131,6 +190,7 @@ If no qualifying legislation is found after exhausting your searches, respond wi
 - Never include legislation from outside {input_city} jurisdiction
 - Never include a finding with fewer than the required source minimum
 - Never editorialize or assess whether legislation is "good" or "bad"
+- Never classify impact based on sponsor party, ideology, or political controversy — apply subject-matter categories symmetrically per Step 3.5a
 - If a source requires a paywall to verify, note it as unverified and do not count it toward the source minimum
 """
 
@@ -150,6 +210,21 @@ Reject:
   - Aggregators that merely *mention* legislation without specifics
   - Paywalled content you cannot verify
   - Irrelevant domains (marketing, social media landing pages)
+
+Impact assessment — also flag whether the legislation at this URL appears to be:
+  - HIGH impact: broadly affects residents (housing, safety, transit, health,
+    labor, education, civil rights, major budget/tax changes, environment)
+  - LOW impact: technical/administrative code changes, ceremonial resolutions,
+    narrow industry regulations, internal process changes, routine procurement
+
+Nonpartisan impact rules (binding):
+  - Classify based on subject matter and resident effect only — never based
+    on sponsor party, ideology, or political controversy level.
+  - Each HIGH-impact category applies symmetrically: e.g., a policing-expansion
+    bill and a policing-oversight bill are both "public safety" and both HIGH.
+  - Do not use evaluative language (radical, sensible, overreach, landmark) in
+    your reasoning. Describe the mechanism of the legislation, not its merit.
+  - When uncertain between HIGH and LOW, default to HIGH.
 
 Produce a single structured assessment. Do not browse; reason only from the
 URL + title/snippet context provided.

--- a/pipelines/node/report_formatter.py
+++ b/pipelines/node/report_formatter.py
@@ -19,8 +19,6 @@ def report_formatter(inputs: ChainData) -> ChainData:
 
     for item in legislation_summary.items:
         lines.append(f"**{item.header}**")
-        if city:
-            lines.append(city)
         lines.append("")
         lines.append(item.description)
         lines.append("")


### PR DESCRIPTION
## Summary

- Add Step 3.5 (Impact Screening) to the legislation finder system prompt — only HIGH-impact legislation that affects residents' daily lives is included. Technical code amendments, ceremonial resolutions, and niche regulations are hard-excluded.
- Add Step 3.5a (Nonpartisan Guardrails) — 6 binding rules ensuring impact screening is party-blind and ideologically symmetric.
- Update sub-agent prompt to flag HIGH vs LOW impact with the same nonpartisan rules.
- Remove redundant city name from report item headings.

## Test plan

- [ ] `python -m compileall -q .`
- [ ] Run `python main.py "San Francisco"` and verify report items are impactful (housing, safety, transit) not mundane (equipment codes, filing procedures)
- [ ] Compare output quality against previous runs