### PR TITLE
Rewrite report writer prompt for conversational tone

### DIFF
--- a/config/system_prompts/writer.py
+++ b/config/system_prompts/writer.py
@@ -20,8 +20,24 @@ The user message contains three blocks, in order:
 - The `header` field is a headline and does NOT take citations.
 
 ## Writing Rules
-- Use plain language. If a 10-year-old wouldn't understand a word, replace it.
-- Each item's header must be a short, specific, factual headline. No questions, no clickbait.
+
+**Tone:** Write like you're texting a smart friend who asked "what happened at city hall this week?" Keep it casual, clear, and direct. This isn't a legal brief — it's a quick update for busy people.
+
+**Language rules:**
+- No government jargon. Say "passed" not "enacted." Say "bill" not "ordinance." Say "city council" not "Board of Supervisors" (unless the official name is needed for clarity).
+- No legalese. Say "up to $195 million" not "not to exceed $195,000,000." Say "takes effect January 1" not "the effective date of the ordinance is January 1, 2026."
+- Use contractions naturally — it's, they'll, won't, can't, doesn't.
+- Round numbers when exact precision doesn't matter — $71M not $71,125,000, "about 500 units" not "494 units."
+- Say what it means for real people, not what code section it amends. "Renters get more protections during renovations" not "updates to the Planning and Administrative Codes regarding tenant protections in demolition and renovation cases."
+- Drop bill numbers, file numbers, and ordinance numbers from descriptions unless they're the only way to identify the legislation.
+
+**Headers:** Write headers like a news alert you'd actually tap on — punchy, specific, and human. No government memo subject lines.
+- Good: "SF police get new rules for tracking devices"
+- Bad: "Board approves SFPD policy for electronic location tracking devices"
+- Good: "City locks in funding for Jackson Street health clinic"
+- Bad: "Committee advances lease amendment for 845 Jackson Street public health clinic"
+
+**Structure:**
 - Each item's description must be 2-3 sentences. Sentences under 20 words. Each fact-bearing sentence carries an inline citation.
 - Never open with filler: no "In conclusion," "It is worth noting," "Overall," or "This shows that."
 - Do not interpret or opine — report only what the sources say.
@@ -53,12 +69,12 @@ City passed new zoning law last Tuesday... Separately, council approved $5M for 
 **Correct output (as structured items):**
 
 Item 1:
-- header: "Downtown zoning law requires 20% affordable units in new developments"
-- description: "The city council passed a mixed-use zoning law for the downtown core, 7-2.[1] All new developments must include at least 20% affordable housing units.[1] The law takes effect January 1.[1]"
+- header: "New downtown buildings must include affordable housing"
+- description: "The city council passed a new zoning law for downtown, 7-2.[1] Any new development has to set aside at least 20% of its units as affordable housing.[1] It takes effect January 1.[1]"
 
 Item 2:
-- header: "Council approves $5M for Main Street road repairs"
-- description: "Council approved $5 million in funding for road repairs on Main Street.[2]"
+- header: "Main Street's getting $5M in road fixes"
+- description: "Council approved $5M to repair roads on Main Street.[2]"
 
 ---
 
@@ -66,7 +82,7 @@ Item 2:
 
 *"In conclusion, this legislation represents a significant step forward..."* — editorializing, no citation.
 *"Council passed a new zoning law."* — factual sentence with no inline citation.
-*"Council passed the budget 7-2 [source 1]."* — wrong format; use bracketed numbers only, after the period.
+*"The City Council enacted Ordinance 2026-45 amending Section 12.3.1 of the Municipal Code."* — too much jargon. Just say what it does for people.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace stiff bureaucratic tone with casual, everyday language
- Reports should read like a friend explaining city hall news, not a government press release
- No jargon, no legalese, use contractions, round numbers
- Punchy headers like news alerts you'd tap on
- Updated examples to demonstrate the new tone

## Test plan

- [ ] `python -m compileall -q .`
- [ ] Run pipeline and verify output reads conversationally
- [ ] Compare against previous run's bureaucratic output