### PR TITLE
Rename cities to regions, cache SQS client, and update ECS task def in CI

### DIFF
--- a/.github/workflows/push-image-to-ecr.yml
+++ b/.github/workflows/push-image-to-ecr.yml
@@ -44,3 +44,25 @@ jobs:
           docker build -f docker/Dockerfile -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -t $REGISTRY/$REPOSITORY:latest .
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:latest
+
+      - name: Update ECS task definition with new image
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          TASK_FAMILY="default-next-voters-agent-62fd"
+          NEW_IMAGE="$REGISTRY/$REPOSITORY:$IMAGE_TAG"
+
+          aws ecs describe-task-definition \
+            --task-definition "$TASK_FAMILY" \
+            --query taskDefinition \
+            > task-def.json
+
+          jq --arg IMG "$NEW_IMAGE" \
+            '.containerDefinitions[0].image = $IMG |
+             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)' \
+            task-def.json > updated-task-def.json
+
+          aws ecs register-task-definition \
+            --cli-input-json file://updated-task-def.json

--- a/utils/sqs_client.py
+++ b/utils/sqs_client.py
@@ -16,9 +16,11 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+_sqs_client = None
+
 
 def get_sqs_client():
-    """Create and return a boto3 SQS client.
+    """Return a cached boto3 SQS client, creating one on first call.
 
     Credentials are discovered automatically from the environment
     (IAM role in Fargate, env vars or ~/.aws locally).
@@ -26,7 +28,10 @@ def get_sqs_client():
     Returns:
         boto3 SQS client.
     """
-    return boto3.client("sqs")
+    global _sqs_client
+    if _sqs_client is None:
+        _sqs_client = boto3.client("sqs")
+    return _sqs_client
 
 
 def enqueue_report(region: str, report_id: int) -> bool:


### PR DESCRIPTION
## Summary
- Rename `supported_cities` table to `regions` and all `city` columns to `region` across the codebase
- Cache SQS client at module level to avoid repeated instantiation
- Add CI step to register a new ECS task definition revision after successful ECR image push

## Test plan
- [ ] Verify `python -m compileall -q .` passes
- [ ] Run `python main.py <region>` to confirm region rename works end-to-end
- [ ] Trigger the ECR workflow via `workflow_dispatch` and confirm the new ECS task definition revision is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)