### PR TITLE
Fix ruff I001 import ordering across tests and tools

### DIFF
--- a/tests/integration/test_container_mode.py
+++ b/tests/integration/test_container_mode.py
@@ -10,10 +10,8 @@ never exists in main's module-level namespace.
 
 from unittest.mock import patch
 
-
 from main import run_container_mode
 from utils.schemas.pydantic import LegislationItem, WriterOutput
-
 
 # ---------------------------------------------------------------------------
 # Patch target constants — keeps the test bodies readable

--- a/tests/integration/test_pipeline_nodes.py
+++ b/tests/integration/test_pipeline_nodes.py
@@ -6,9 +6,7 @@ flows correctly through the composed node chain.
 
 from unittest.mock import MagicMock, patch
 
-
 from utils.schemas.pydantic import LegislationItem, WriterOutput
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_compressor.py
+++ b/tests/unit/test_compressor.py
@@ -2,10 +2,8 @@
 
 from unittest.mock import patch
 
-
 from config.constants import COMPRESSION_RATE, MIN_CHARS_TO_COMPRESS
 from utils.content.compressor import compress_text
-
 
 SHORT_TEXT = "Short."  # well below MIN_CHARS_TO_COMPRESS
 LONG_TEXT = "x " * (MIN_CHARS_TO_COMPRESS + 100)  # guaranteed above the threshold

--- a/tests/unit/test_note_taker.py
+++ b/tests/unit/test_note_taker.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock, patch
 
 
-
 def _make_llm_response(text: str):
     """Build a mock LLM response with the given content string."""
     response = MagicMock()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2,14 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-
 from utils.report.storage import (
     _normalize_source_urls,
     _resolve_source_urls,
     save_report,
 )
 from utils.schemas.pydantic import LegislationItem, WriterOutput
-
 
 # ---------------------------------------------------------------------------
 # _normalize_source_urls

--- a/tests/unit/test_summary_writer.py
+++ b/tests/unit/test_summary_writer.py
@@ -2,14 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
-
 from pipelines.node.summary_writer import (
     _build_user_message,
     _normalize_source_urls,
     research_summary_writer,
 )
 from utils.schemas.pydantic import WriterOutput
-
 
 # ---------------------------------------------------------------------------
 # _normalize_source_urls

--- a/tools/researcher_agent_tool.py
+++ b/tools/researcher_agent_tool.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from langchain_core.messages import ToolMessage
-from langchain_core.tools import tool, InjectedToolCallId
+from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.prebuilt.tool_node import InjectedState
 from langgraph.types import Command
 
 from config.constants import MAX_RESEARCHER_INVOCATIONS
 from utils.agents import invoke_researcher_agent
-
 
 # ---------------------------------------------------------------------------
 # Tool

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -15,7 +15,7 @@ from langgraph.prebuilt.tool_node import InjectedState
 from langgraph.types import Command
 
 from config.constants import WEB_SEARCH_MAX_RESULTS, WEB_SEARCH_PER_URL_CHAR_CAP
-from tools._helpers import ok, err
+from tools._helpers import err, ok
 from tools.services.extract import extract_url_content
 from tools.services.tavily import search_legislation
 from utils.content.compressor import compress_text

--- a/utils/agents/__init__.py
+++ b/utils/agents/__init__.py
@@ -1,6 +1,6 @@
+from utils.agents._helpers import reconcile_sources
 from utils.agents.invoke_lead_researcher import invoke_lead_researcher_agent
 from utils.agents.invoke_researcher import invoke_researcher_agent
-from utils.agents._helpers import reconcile_sources
 
 __all__ = [
     "invoke_lead_researcher_agent",

--- a/utils/agents/invoke_researcher.py
+++ b/utils/agents/invoke_researcher.py
@@ -6,7 +6,6 @@ from agents.researcher_agent import build_researcher_agent
 from config.constants import AGENT_RECURSION_LIMIT
 from utils.agents._helpers import reconcile_sources
 
-
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes 10 ruff `I001` import-ordering violations across test files and tool modules
- Sorts import blocks to stdlib → third-party → local ordering and alphabetizes within blocks
- No logic changes — purely cosmetic import reordering

## Changes
- `tests/integration/test_container_mode.py`
- `tests/integration/test_pipeline_nodes.py`
- `tests/unit/test_compressor.py`
- `tests/unit/test_note_taker.py`
- `tests/unit/test_storage.py`
- `tests/unit/test_summary_writer.py`
- `tools/researcher_agent_tool.py`
- `tools/web_search.py`
- `utils/agents/__init__.py`
- `utils/agents/invoke_researcher.py`

## Test plan
- [x] `ruff check` passes with zero errors on all modified files
- [x] Pre-commit hooks passed (ruff, compileall, trailing whitespace, end-of-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)